### PR TITLE
[FEAT] 스터디 그룹 업데이트 기능을 구현하라

### DIFF
--- a/src/main/docs/study-group.adoc
+++ b/src/main/docs/study-group.adoc
@@ -3,3 +3,7 @@
 === 생성
 operation::post-study-group[snippets='http-request,request-parts,request-parameters,response-headers,response-fields,response-body']
 '''
+
+=== 업데이트
+operation::patch-study-group[snippets='http-request,request-parts,request-parameters,response-headers,response-fields,response-body']
+'''

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupMapper.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupMapper.java
@@ -3,8 +3,10 @@ package prgrms.project.stuti.domain.studygroup.controller;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupCreateRequest;
+import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupUpdateRequest;
 import prgrms.project.stuti.domain.studygroup.model.Region;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class StudyGroupMapper {
@@ -23,6 +25,18 @@ public class StudyGroupMapper {
 			.startDateTime(createRequest.startDateTime())
 			.endDateTime(createRequest.endDateTime())
 			.description(createRequest.description())
+			.build();
+	}
+
+	public static StudyGroupUpdateDto toStudyGroupUpdateDto(Long memberId, Long studyGroupId,
+		StudyGroupUpdateRequest updateRequest) {
+		return StudyGroupUpdateDto
+			.builder()
+			.memberId(memberId)
+			.studyGroupId(studyGroupId)
+			.title(updateRequest.title())
+			.imageFile(updateRequest.imageFile())
+			.description(updateRequest.description())
 			.build();
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
@@ -7,15 +7,19 @@ import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupCreateRequest;
+import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupUpdateRequest;
 import prgrms.project.stuti.domain.studygroup.service.StudyGroupService;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 
 @RestController
 @RequestMapping("/api/v1/study-groups")
@@ -32,5 +36,14 @@ public class StudyGroupRestController {
 		URI uri = URI.create("/api/v1/study-groups/" + idResponse.studyGroupId());
 
 		return ResponseEntity.created(uri).body(idResponse);
+	}
+
+	@PatchMapping("/{studyGroupId}")
+	public ResponseEntity<StudyGroupIdResponse> updateStudyGroup(@AuthenticationPrincipal Long memberId,
+		@PathVariable Long studyGroupId, @Valid @ModelAttribute StudyGroupUpdateRequest updateRequest) {
+		StudyGroupUpdateDto updateDto = StudyGroupMapper.toStudyGroupUpdateDto(memberId, studyGroupId, updateRequest);
+		StudyGroupIdResponse idResponse = studyGroupService.updateStudyGroup(updateDto);
+
+		return ResponseEntity.ok(idResponse);
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/dto/StudyGroupUpdateRequest.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/dto/StudyGroupUpdateRequest.java
@@ -1,0 +1,21 @@
+package prgrms.project.stuti.domain.studygroup.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import prgrms.project.stuti.domain.studygroup.controller.dto.validator.DescriptionLength;
+import prgrms.project.stuti.domain.studygroup.controller.dto.validator.TitleLength;
+
+public record StudyGroupUpdateRequest(
+	@NotBlank
+	@TitleLength
+	String title,
+
+	MultipartFile imageFile,
+
+	@NotBlank
+	@DescriptionLength
+	String description
+) {
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/model/StudyGroup.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/model/StudyGroup.java
@@ -80,6 +80,19 @@ public class StudyGroup extends BaseEntity {
 		this.isDeleted = false;
 	}
 
+	public void updateImage(String imageUrl, String thumbnailUrl) {
+		this.imageUrl = imageUrl;
+		this.thumbnailUrl = thumbnailUrl;
+	}
+
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateDescription(String description) {
+		this.description = description;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this,

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/StudyMemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/StudyMemberRepository.java
@@ -1,8 +1,0 @@
-package prgrms.project.stuti.domain.studygroup.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import prgrms.project.stuti.domain.studygroup.model.StudyMember;
-
-public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
-}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepository.java
@@ -1,0 +1,6 @@
+package prgrms.project.stuti.domain.studygroup.repository.studymember;
+
+public interface CustomStudyMemberRepository {
+
+	boolean isLeader(Long memberId, Long studyGroupId);
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepositoryImpl.java
@@ -1,0 +1,32 @@
+package prgrms.project.stuti.domain.studygroup.repository.studymember;
+
+import static prgrms.project.stuti.domain.studygroup.model.QStudyMember.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.member.model.QMember;
+import prgrms.project.stuti.domain.studygroup.model.QStudyGroup;
+import prgrms.project.stuti.domain.studygroup.model.QStudyMember;
+import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
+
+@RequiredArgsConstructor
+public class CustomStudyMemberRepositoryImpl implements CustomStudyMemberRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public boolean isLeader(Long memberId, Long studyGroupId) {
+		QStudyGroup studyGroup = studyMember.studyGroup;
+		QMember member = studyMember.member;
+
+		Integer result = jpaQueryFactory
+			.selectOne()
+			.from(QStudyMember.studyMember)
+			.where(QStudyMember.studyMember.studyMemberRole.eq(StudyMemberRole.LEADER), member.id.eq(memberId),
+				studyGroup.id.eq(studyGroupId), studyGroup.isDeleted.isFalse())
+			.fetchFirst();
+
+		return result != null;
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepository.java
@@ -1,0 +1,8 @@
+package prgrms.project.stuti.domain.studygroup.repository.studymember;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import prgrms.project.stuti.domain.studygroup.model.StudyMember;
+
+public interface StudyMemberRepository extends JpaRepository<StudyMember, Long>, CustomStudyMemberRepository {
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/dto/StudyGroupUpdateDto.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/dto/StudyGroupUpdateDto.java
@@ -1,0 +1,18 @@
+package prgrms.project.stuti.domain.studygroup.service.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Builder;
+
+public record StudyGroupUpdateDto(
+	Long memberId,
+	Long studyGroupId,
+	String title,
+	MultipartFile imageFile,
+	String description
+) {
+
+	@Builder
+	public StudyGroupUpdateDto {
+	}
+}

--- a/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
+++ b/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
 
 	//study group
 	INVALID_STUDY_PERIOD("SG001", "Invalid study period", HttpStatus.BAD_REQUEST),
+	NOT_FOUND_STUDY_GROUP("SG002", "Not found study group", HttpStatus.NOT_FOUND),
+	NOT_LEADER("SG003", "Not leader", HttpStatus.BAD_REQUEST),
 
 	//file
 	EMPTY_FILE("F001", "Uploaded empty file", HttpStatus.BAD_REQUEST),

--- a/src/main/java/prgrms/project/stuti/global/error/exception/StudyGroupException.java
+++ b/src/main/java/prgrms/project/stuti/global/error/exception/StudyGroupException.java
@@ -16,4 +16,16 @@ public class StudyGroupException extends BusinessException {
 			MessageFormat.format(
 				"유효하지 않은 스터디 기간입니다. (startDateTime: {0}, endDateTime: {1}", startDateTime, endDateTime));
 	}
+
+	public static StudyGroupException notFoundStudyGroup(Long studyGroupId) {
+		return new StudyGroupException(ErrorCode.NOT_FOUND_STUDY_GROUP,
+			MessageFormat.format(
+				"스터디 그룹을 찾을 수 없습니다. (studyGroupId: {0}", studyGroupId));
+	}
+
+	public static StudyGroupException notLeader(Long memberId, Long studyGroupId) {
+		return new StudyGroupException(ErrorCode.NOT_LEADER,
+			MessageFormat.format(
+				"스터디 그룹의 리더가 아닙니다. (memberId: {0}, studyGroupId: {1})", memberId, studyGroupId));
+	}
 }

--- a/src/test/java/prgrms/project/stuti/config/RepositoryTestConfig.java
+++ b/src/test/java/prgrms/project/stuti/config/RepositoryTestConfig.java
@@ -1,10 +1,13 @@
 package prgrms.project.stuti.config;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 import prgrms.project.stuti.domain.member.model.Career;
 import prgrms.project.stuti.domain.member.model.Field;
@@ -12,10 +15,13 @@ import prgrms.project.stuti.domain.member.model.Mbti;
 import prgrms.project.stuti.domain.member.model.Member;
 import prgrms.project.stuti.domain.member.model.MemberRole;
 import prgrms.project.stuti.domain.member.repository.MemberRepository;
+import prgrms.project.stuti.global.config.JpaAuditConfig;
+import prgrms.project.stuti.global.config.QuerydslConfig;
 
-@SpringBootTest
+@DataJpaTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class ServiceTestConfig {
+@Import( { QuerydslConfig.class, JpaAuditConfig.class } )
+public abstract class RepositoryTestConfig {
 
 	@Autowired
 	protected MemberRepository memberRepository;

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
@@ -1,0 +1,76 @@
+package prgrms.project.stuti.domain.studygroup.repository.studymember;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import prgrms.project.stuti.config.RepositoryTestConfig;
+import prgrms.project.stuti.domain.studygroup.model.Region;
+import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
+import prgrms.project.stuti.domain.studygroup.model.StudyMember;
+import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
+import prgrms.project.stuti.domain.studygroup.model.StudyPeriod;
+import prgrms.project.stuti.domain.studygroup.model.Topic;
+import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
+
+class StudyMemberRepositoryTest extends RepositoryTestConfig {
+
+	@Autowired
+	private StudyMemberRepository studyMemberRepository;
+
+	@Autowired
+	private StudyGroupRepository studyGroupRepository;
+
+	private StudyGroup studyGroup;
+
+	@BeforeAll
+	void setup() {
+		this.studyGroup = studyGroupRepository.save(
+			StudyGroup
+				.builder()
+				.imageUrl("imageUrl")
+				.thumbnailUrl("thumbnailUrl")
+				.title("test title")
+				.topic(Topic.NETWORK)
+				.isOnline(true)
+				.region(Region.ONLINE)
+				.numberOfRecruits(5)
+				.studyPeriod(new StudyPeriod(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusMonths(10)))
+				.description("description")
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("해당 스터디의 리더라면 true 를 반환한다.")
+	void testIsLeader() {
+		//given
+		studyMemberRepository.save(new StudyMember(StudyMemberRole.LEADER, member, studyGroup));
+
+		//when
+		boolean isLeader = studyMemberRepository.isLeader(member.getId(), studyGroup.getId());
+
+		//then
+		assertTrue(isLeader);
+	}
+
+	@Test
+	@DisplayName("해당 스터디의 리더가 아니라면 false 를 반환한다.")
+	void testIsNotLeader() {
+		//given
+		studyMemberRepository.save(new StudyMember(StudyMemberRole.STUDY_MEMBER, member, studyGroup));
+
+		//when
+		boolean isLeader = studyMemberRepository.isLeader(member.getId(), studyGroup.getId());
+
+		//then
+		assertFalse(isLeader);
+	}
+}
+

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
@@ -9,6 +9,10 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,14 +22,32 @@ import org.springframework.web.multipart.MultipartFile;
 import prgrms.project.stuti.config.ServiceTestConfig;
 import prgrms.project.stuti.domain.member.model.Mbti;
 import prgrms.project.stuti.domain.studygroup.model.Region;
+import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
+import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
+import prgrms.project.stuti.global.error.exception.StudyGroupException;
 
+@Transactional
 class StudyGroupServiceTest extends ServiceTestConfig {
 
 	@Autowired
 	private StudyGroupService studyGroupService;
+
+	@Autowired
+	private StudyGroupRepository studyGroupRepository;
+
+	private StudyGroup studyGroup;
+
+	@BeforeEach
+	void setup() throws IOException {
+		StudyGroupCreateDto createDto = toCreateDto(member.getId());
+		StudyGroupIdResponse idResponse = studyGroupService.createStudyGroup(createDto);
+		this.studyGroup = studyGroupRepository.findById(idResponse.studyGroupId())
+			.orElseThrow(() -> new IllegalArgumentException("failed to find studyGroup"));
+	}
 
 	@Test
 	@DisplayName("새로운 스터디 그룹을 생성한다.")
@@ -35,10 +57,54 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 
 		//when
 		StudyGroupIdResponse idResponse = studyGroupService.createStudyGroup(createDto);
+		StudyGroup studyGroup = studyGroupRepository.findById(idResponse.studyGroupId())
+			.orElseThrow(() -> StudyGroupException.notFoundStudyGroup(idResponse.studyGroupId()));
+
+		//then
+		assertEquals(createDto.title(), studyGroup.getTitle());
+		assertEquals(createDto.description(), studyGroup.getDescription());
+	}
+
+	@Test
+	@DisplayName("스터디의 이미지, 제목, 설명을 업데이트한다.")
+	void testUpdateStudyGroup() throws IOException {
+		//given
+		String updateTitle = "update title";
+		String updateDescription = "update description";
+		String imageUrlBeforeUpdate = studyGroup.getImageUrl();
+		StudyGroupUpdateDto updateDto = toUpdateDto(member.getId(), studyGroup.getId(), updateTitle, getMultipartFile(),
+			updateDescription);
+
+		//when
+		StudyGroupIdResponse idResponse = studyGroupService.updateStudyGroup(updateDto);
 
 		//then
 		assertNotNull(idResponse);
-		assertEquals(1L, idResponse.studyGroupId());
+		assertEquals(studyGroup.getId(), idResponse.studyGroupId());
+		assertNotEquals(imageUrlBeforeUpdate, studyGroup.getImageUrl());
+		assertEquals(updateTitle, studyGroup.getTitle());
+		assertEquals(updateDescription, studyGroup.getDescription());
+	}
+
+	@Test
+	@DisplayName("새로운 이미지를 업로드 하지 않고, 제목, 설명이 전과 같다면 업데이트하지 않는다.")
+	void testUpdateStudyGroupWithSameValueAsBefore() throws IOException {
+		//given
+		String updateTitle = studyGroup.getTitle();
+		String updateDescription = studyGroup.getDescription();
+		String imageUrlBeforeUpdate = studyGroup.getImageUrl();
+		StudyGroupUpdateDto updateDto = toUpdateDto(member.getId(), studyGroup.getId(), updateTitle, null,
+			updateDescription);
+
+		//when
+		StudyGroupIdResponse idResponse = studyGroupService.updateStudyGroup(updateDto);
+
+		//then
+		assertNotNull(idResponse);
+		assertEquals(studyGroup.getId(), idResponse.studyGroupId());
+		assertEquals(imageUrlBeforeUpdate, studyGroup.getImageUrl());
+		assertEquals(updateTitle, studyGroup.getTitle());
+		assertEquals(updateDescription, studyGroup.getDescription());
 	}
 
 	private StudyGroupCreateDto toCreateDto(Long memberId) throws IOException {
@@ -55,6 +121,18 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 			.startDateTime(LocalDateTime.now().plusDays(10))
 			.endDateTime(LocalDateTime.now().plusMonths(3))
 			.description("this is new study group")
+			.build();
+	}
+
+	private StudyGroupUpdateDto toUpdateDto(Long memberId, Long studyGroupId, String updateTitle,
+		MultipartFile imageFile, String updateDescription) {
+		return StudyGroupUpdateDto
+			.builder()
+			.memberId(memberId)
+			.studyGroupId(studyGroupId)
+			.title(updateTitle)
+			.imageFile(imageFile)
+			.description(updateDescription)
 			.build();
 	}
 


### PR DESCRIPTION
## ✅ PR 포인트
- 스터디 그룹 업데이트 기능을 구현하였습니다.
- 이미지, 제목, 설명을 수정할 수 있습니다.
- 서비스, 레포지토리 테스트에서 멤버가 공통적으로 사용되고 있어서 따로 클래스로 뺐습니다.

## 🙉 고민했던 부분
- 업데이트를 하는 제목과 설명이 이전과 다르지 않다면 업데이트 쿼리를 날리지 않는 것이 좋을 것 같아서 체크를 한 번 해주도록 했는데 이게 더 낫겠죠???

## 🙋 질문
- 놉