### PR TITLE
[FEAT] 스터디 그룹 가입신청(참가신청) 기능을 구현하라

### DIFF
--- a/src/main/docs/study-group.adoc
+++ b/src/main/docs/study-group.adoc
@@ -7,3 +7,7 @@ operation::post-study-group[snippets='http-request,request-parts,request-paramet
 === 업데이트
 operation::patch-study-group[snippets='http-request,request-parts,request-parameters,response-headers,response-fields,response-body']
 '''
+
+=== 스터디 신청
+operation::post-apply-study-group[snippets='http-request,path-parameters,response-headers,response-fields,response-body']
+'''

--- a/src/main/java/prgrms/project/stuti/domain/member/repository/CustomMemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/member/repository/CustomMemberRepository.java
@@ -1,0 +1,10 @@
+package prgrms.project.stuti.domain.member.repository;
+
+import java.util.Optional;
+
+import prgrms.project.stuti.domain.member.model.Member;
+
+public interface CustomMemberRepository {
+
+	Optional<Member> findMemberById(Long memberId);
+}

--- a/src/main/java/prgrms/project/stuti/domain/member/repository/CustomMemberRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/member/repository/CustomMemberRepositoryImpl.java
@@ -1,0 +1,31 @@
+package prgrms.project.stuti.domain.member.repository;
+
+import static prgrms.project.stuti.domain.member.model.QMember.*;
+
+import java.util.Optional;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.member.model.Member;
+
+@RequiredArgsConstructor
+public class CustomMemberRepositoryImpl implements CustomMemberRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Optional<Member> findMemberById(Long memberId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(member)
+				.where(member.id.eq(memberId), isNotDeleted())
+				.fetchOne()
+		);
+	}
+
+	private BooleanExpression isNotDeleted() {
+		return member.isDeleted.isFalse();
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/member/repository/MemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/member/repository/MemberRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import prgrms.project.stuti.domain.member.model.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, CustomMemberRepository {
 	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupMapper.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupMapper.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupCreateRequest;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupUpdateRequest;
 import prgrms.project.stuti.domain.studygroup.model.Region;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupApplyDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 
@@ -38,5 +39,9 @@ public class StudyGroupMapper {
 			.imageFile(updateRequest.imageFile())
 			.description(updateRequest.description())
 			.build();
+	}
+
+	public static StudyGroupApplyDto toStudyGroupApplyDto(Long memberId, Long studyGroupId) {
+		return new StudyGroupApplyDto(memberId, studyGroupId);
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
@@ -16,10 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupCreateRequest;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupUpdateRequest;
-import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupApplyDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
+import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 
 @RestController
 @RequestMapping("/api/v1/study-groups")
@@ -36,6 +37,15 @@ public class StudyGroupRestController {
 		URI uri = URI.create("/api/v1/study-groups/" + idResponse.studyGroupId());
 
 		return ResponseEntity.created(uri).body(idResponse);
+	}
+
+	@PostMapping("/{studyGroupId}")
+	public ResponseEntity<StudyGroupIdResponse> applyStudyGroup(@AuthenticationPrincipal Long memberId,
+		@PathVariable Long studyGroupId) {
+		StudyGroupApplyDto applyDto = StudyGroupMapper.toStudyGroupApplyDto(memberId, studyGroupId);
+		StudyGroupIdResponse idResponse = studyGroupService.applyStudyGroup(applyDto);
+
+		return ResponseEntity.ok(idResponse);
 	}
 
 	@PatchMapping("/{studyGroupId}")

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupCreateRequest;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupUpdateRequest;
-import prgrms.project.stuti.domain.studygroup.service.StudyGroupService;
+import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/StudyGroupRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/StudyGroupRepository.java
@@ -1,8 +1,0 @@
-package prgrms.project.stuti.domain.studygroup.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
-
-public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
-}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/CustomStudyGroupRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/CustomStudyGroupRepository.java
@@ -1,0 +1,10 @@
+package prgrms.project.stuti.domain.studygroup.repository.studygroup;
+
+import java.util.Optional;
+
+import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
+
+public interface CustomStudyGroupRepository {
+
+	Optional<StudyGroup> findStudyGroupById(Long studyGroupId);
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/CustomStudyGroupRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/CustomStudyGroupRepositoryImpl.java
@@ -1,0 +1,31 @@
+package prgrms.project.stuti.domain.studygroup.repository.studygroup;
+
+import static prgrms.project.stuti.domain.studygroup.model.QStudyGroup.*;
+
+import java.util.Optional;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
+
+@RequiredArgsConstructor
+public class CustomStudyGroupRepositoryImpl implements CustomStudyGroupRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Optional<StudyGroup> findStudyGroupById(Long studyGroupId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(studyGroup)
+				.where(studyGroup.id.eq(studyGroupId), isNotDeleted())
+				.fetchOne()
+		);
+	}
+
+	private BooleanExpression isNotDeleted() {
+		return studyGroup.isDeleted.isFalse();
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/StudyGroupRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/StudyGroupRepository.java
@@ -1,0 +1,8 @@
+package prgrms.project.stuti.domain.studygroup.repository.studygroup;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
+
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>, CustomStudyGroupRepository {
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepositoryImpl.java
@@ -1,13 +1,13 @@
 package prgrms.project.stuti.domain.studygroup.repository.studymember;
 
+import static prgrms.project.stuti.domain.member.model.QMember.*;
+import static prgrms.project.stuti.domain.studygroup.model.QStudyGroup.*;
 import static prgrms.project.stuti.domain.studygroup.model.QStudyMember.*;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
-import prgrms.project.stuti.domain.member.model.QMember;
-import prgrms.project.stuti.domain.studygroup.model.QStudyGroup;
-import prgrms.project.stuti.domain.studygroup.model.QStudyMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
 
 @RequiredArgsConstructor
@@ -17,16 +17,23 @@ public class CustomStudyMemberRepositoryImpl implements CustomStudyMemberReposit
 
 	@Override
 	public boolean isLeader(Long memberId, Long studyGroupId) {
-		QStudyGroup studyGroup = studyMember.studyGroup;
-		QMember member = studyMember.member;
-
 		Integer result = jpaQueryFactory
 			.selectOne()
-			.from(QStudyMember.studyMember)
-			.where(QStudyMember.studyMember.studyMemberRole.eq(StudyMemberRole.LEADER), member.id.eq(memberId),
-				studyGroup.id.eq(studyGroupId), studyGroup.isDeleted.isFalse())
+			.from(studyMember)
+			.join(studyMember.member, member)
+			.join(studyMember.studyGroup, studyGroup)
+			.where(studyMember.studyMemberRole.eq(StudyMemberRole.LEADER), isNotDeletedMember(memberId),
+				isNotDeletedStudyGroup(studyGroupId))
 			.fetchFirst();
 
 		return result != null;
+	}
+
+	public BooleanExpression isNotDeletedMember(Long memberId) {
+		return member.id.eq(memberId).and(member.isDeleted.isFalse());
+	}
+
+	public BooleanExpression isNotDeletedStudyGroup(Long studyGroupId) {
+		return studyGroup.id.eq(studyGroupId).and(studyGroup.isDeleted.isFalse());
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import prgrms.project.stuti.domain.studygroup.model.StudyMember;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long>, CustomStudyMemberRepository {
+
+	boolean existsByMemberIdAndStudyGroupId(Long memberId, Long studyGroupId);
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/dto/StudyGroupApplyDto.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/dto/StudyGroupApplyDto.java
@@ -1,0 +1,7 @@
+package prgrms.project.stuti.domain.studygroup.service.dto;
+
+public record StudyGroupApplyDto(
+	Long memberId,
+	Long studyGroupId
+) {
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupConverter.java
@@ -1,4 +1,4 @@
-package prgrms.project.stuti.domain.studygroup.service;
+package prgrms.project.stuti.domain.studygroup.service.studygroup;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
@@ -1,4 +1,4 @@
-package prgrms.project.stuti.domain.studygroup.service;
+package prgrms.project.stuti.domain.studygroup.service.studygroup;
 
 import java.util.List;
 

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
@@ -15,7 +15,7 @@ import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.StudyMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
 import prgrms.project.stuti.domain.studygroup.repository.PreferredMbtiRepository;
-import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
+import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyMemberRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupApplyDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
@@ -130,11 +130,11 @@ public class StudyGroupService {
 	}
 
 	private Member getMember(Long memberId) {
-		return memberRepository.findById(memberId).orElseThrow(() -> MemberException.notFoundMember(memberId));
+		return memberRepository.findMemberById(memberId).orElseThrow(() -> MemberException.notFoundMember(memberId));
 	}
 
 	private StudyGroup getStudyGroup(Long studyGroupId) {
-		return studyGroupRepository.findById(studyGroupId)
+		return studyGroupRepository.findStudyGroupById(studyGroupId)
 			.orElseThrow(() -> StudyGroupException.notFoundStudyGroup(studyGroupId));
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
@@ -17,6 +17,7 @@ import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
 import prgrms.project.stuti.domain.studygroup.repository.PreferredMbtiRepository;
 import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyMemberRepository;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupApplyDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
@@ -42,7 +43,7 @@ public class StudyGroupService {
 
 		StudyGroup studyGroup = saveStudyGroup(createDto, imageUrl, thumbnailUrl);
 		savePreferredMbtis(createDto.preferredMBTIs(), studyGroup);
-		saveStudyLeader(createDto.memberId(), studyGroup);
+		saveStudyGroupLeader(createDto.memberId(), studyGroup);
 
 		return StudyGroupConverter.toStudyGroupIdResponse(studyGroup.getId());
 	}
@@ -59,6 +60,17 @@ public class StudyGroupService {
 		return StudyGroupConverter.toStudyGroupIdResponse(studyGroup.getId());
 	}
 
+	@Transactional
+	public StudyGroupIdResponse applyStudyGroup(StudyGroupApplyDto applyDto) {
+		Long memberId = applyDto.memberId();
+		Long studyGroupId = applyDto.studyGroupId();
+
+		validateExistingStudyMember(memberId, studyGroupId);
+		saveStudyGroupApplicant(memberId, studyGroupId);
+
+		return StudyGroupConverter.toStudyGroupIdResponse(studyGroupId);
+	}
+
 	private StudyGroup saveStudyGroup(StudyGroupCreateDto createDto, String imageUrl, String thumbnailUrl) {
 		StudyGroup studyGroup = StudyGroupConverter.toStudyGroup(createDto, imageUrl, thumbnailUrl);
 
@@ -70,14 +82,23 @@ public class StudyGroupService {
 			preferredMbtis.stream().map(mbti -> new PreferredMbti(mbti, studyGroup)).toList());
 	}
 
-	private void saveStudyLeader(Long memberId, StudyGroup studyGroup) {
+	private void saveStudyGroupLeader(Long memberId, StudyGroup studyGroup) {
 		Member member = getMember(memberId);
 
 		studyMemberRepository.save(new StudyMember(StudyMemberRole.LEADER, member, studyGroup));
 	}
 
+	private void saveStudyGroupApplicant(Long memberId, Long studyGroupId) {
+		Member member = getMember(memberId);
+		StudyGroup studyGroup = getStudyGroup(studyGroupId);
+
+		studyMemberRepository.save(new StudyMember(StudyMemberRole.APPLICANT, member, studyGroup));
+	}
+
 	private void updateStudyGroupImage(MultipartFile imageFile, StudyGroup studyGroup) {
-		if (imageFile == null || imageFile.isEmpty()) return;
+		if (imageFile == null || imageFile.isEmpty()) {
+			return;
+		}
 
 		String imageUrl = imageUploader.upload(imageFile, ImageDirectory.STUDY_GROUP);
 		String thumbnailUrl = imageUploader.createThumbnail(imageUrl);
@@ -97,6 +118,14 @@ public class StudyGroupService {
 
 		if (!isLeader) {
 			throw StudyGroupException.notLeader(memberId, studyGroupId);
+		}
+	}
+
+	private void validateExistingStudyMember(Long memberId, Long studyGroupId) {
+		boolean isExists = studyMemberRepository.existsByMemberIdAndStudyGroupId(memberId, studyGroupId);
+
+		if (isExists) {
+			throw StudyGroupException.existingStudyMember(memberId, studyGroupId);
 		}
 	}
 

--- a/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
+++ b/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
 	INVALID_STUDY_PERIOD("SG001", "Invalid study period", HttpStatus.BAD_REQUEST),
 	NOT_FOUND_STUDY_GROUP("SG002", "Not found study group", HttpStatus.NOT_FOUND),
 	NOT_LEADER("SG003", "Not leader", HttpStatus.BAD_REQUEST),
-	EXISTING_STUDY_MEMBER("SG003", "Existing study member", HttpStatus.BAD_REQUEST),
+	EXISTING_STUDY_MEMBER("SG004", "Existing study member", HttpStatus.BAD_REQUEST),
 
 	//file
 	EMPTY_FILE("F001", "Uploaded empty file", HttpStatus.BAD_REQUEST),

--- a/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
+++ b/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 	INVALID_STUDY_PERIOD("SG001", "Invalid study period", HttpStatus.BAD_REQUEST),
 	NOT_FOUND_STUDY_GROUP("SG002", "Not found study group", HttpStatus.NOT_FOUND),
 	NOT_LEADER("SG003", "Not leader", HttpStatus.BAD_REQUEST),
+	EXISTING_STUDY_MEMBER("SG003", "Existing study member", HttpStatus.BAD_REQUEST),
 
 	//file
 	EMPTY_FILE("F001", "Uploaded empty file", HttpStatus.BAD_REQUEST),

--- a/src/main/java/prgrms/project/stuti/global/error/exception/StudyGroupException.java
+++ b/src/main/java/prgrms/project/stuti/global/error/exception/StudyGroupException.java
@@ -28,4 +28,10 @@ public class StudyGroupException extends BusinessException {
 			MessageFormat.format(
 				"스터디 그룹의 리더가 아닙니다. (memberId: {0}, studyGroupId: {1})", memberId, studyGroupId));
 	}
+
+	public static StudyGroupException existingStudyMember(Long memberId, Long studyGroupId) {
+		return new StudyGroupException(ErrorCode.EXISTING_STUDY_MEMBER,
+			MessageFormat.format(
+				"이미 존재하는 스터디 멤버입니다. (memberId: {0}, studyGroupId: {1})", memberId, studyGroupId));
+	}
 }

--- a/src/test/java/prgrms/project/stuti/config/ServiceTestConfig.java
+++ b/src/test/java/prgrms/project/stuti/config/ServiceTestConfig.java
@@ -22,6 +22,8 @@ public abstract class ServiceTestConfig {
 
 	protected Member member;
 
+	protected Member member2;
+
 	@BeforeAll
 	void init() {
 		this.member = memberRepository.save(
@@ -35,6 +37,21 @@ public abstract class ServiceTestConfig {
 				.blogUrl("blog.com")
 				.mbti(Mbti.ENFJ)
 				.profileImageUrl("www.s3.com")
+				.memberRole(MemberRole.ROLE_MEMBER)
+				.build()
+		);
+
+		this.member2 = memberRepository.save(
+			Member
+				.builder()
+				.email("test2@gmail.com")
+				.nickName("nickname2")
+				.career(Career.JUNIOR)
+				.field(Field.ANDROID)
+				.githubUrl("github2.com")
+				.blogUrl("blog2.com")
+				.mbti(Mbti.ENFJ)
+				.profileImageUrl("www.s3.com2")
 				.memberRole(MemberRole.ROLE_MEMBER)
 				.build()
 		);

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
@@ -35,7 +35,7 @@ import org.springframework.util.MultiValueMap;
 import prgrms.project.stuti.config.TestConfig;
 import prgrms.project.stuti.domain.studygroup.model.Region;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
-import prgrms.project.stuti.domain.studygroup.service.StudyGroupService;
+import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
 
 @WebMvcTest(controllers = StudyGroupRestController.class)

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.headers.HeaderDescriptor;

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
@@ -2,12 +2,13 @@ package prgrms.project.stuti.domain.studygroup.controller;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static prgrms.project.stuti.domain.studygroup.controller.StudyGroupRestControllerTest.Field.*;
 
@@ -25,6 +26,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 import org.springframework.restdocs.request.RequestPartDescriptor;
@@ -35,8 +37,8 @@ import org.springframework.util.MultiValueMap;
 import prgrms.project.stuti.config.TestConfig;
 import prgrms.project.stuti.domain.studygroup.model.Region;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
-import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
+import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 
 @WebMvcTest(controllers = StudyGroupRestController.class)
 class StudyGroupRestControllerTest extends TestConfig {
@@ -58,7 +60,11 @@ class StudyGroupRestControllerTest extends TestConfig {
 		ResultActions resultActions = mockMvc.perform(multipart("/api/v1/study-groups")
 			.file("imageFile", getMultipartFileBytes())
 			.params(createParams)
-			.contentType(MediaType.MULTIPART_FORM_DATA));
+			.contentType(MediaType.MULTIPART_FORM_DATA)
+			.with(requestPostProcessor -> {
+				requestPostProcessor.setMethod("POST");
+				return requestPostProcessor;
+			}));
 
 		//then
 		resultActions
@@ -67,11 +73,11 @@ class StudyGroupRestControllerTest extends TestConfig {
 				content().json(objectMapper.writeValueAsString(idResponse)))
 			.andDo(
 				document(COMMON_DOCS_NAME,
-					requestHeaders(contentType()).and(host()),
+					requestHeaders(contentType(), host()),
 					requestParts(imageFile()),
 					requestParameters(title()).and(parametersOfCreateStudyGroup()).and(description()),
 					responseHeaders(contentType()).and(location()),
-					responseFields(studyGroupId())));
+					responseFields(studyGroupIdField())));
 	}
 
 	@Test
@@ -85,10 +91,14 @@ class StudyGroupRestControllerTest extends TestConfig {
 
 		//when
 		ResultActions resultActions = mockMvc.perform(
-			multipart(HttpMethod.PATCH, "/api/v1/study-groups/{studyGroupId}", idResponse.studyGroupId())
+			multipart("/api/v1/study-groups/{studyGroupId}", idResponse.studyGroupId())
 				.file("imageFile", getMultipartFileBytes())
 				.params(updateParams)
-				.contentType(MediaType.MULTIPART_FORM_DATA));
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(requestPostProcessor -> {
+					requestPostProcessor.setMethod("PATCH");
+					return requestPostProcessor;
+				}));
 
 		//then
 		resultActions
@@ -97,11 +107,36 @@ class StudyGroupRestControllerTest extends TestConfig {
 				content().json(objectMapper.writeValueAsString(idResponse)))
 			.andDo(
 				document(COMMON_DOCS_NAME,
-					requestHeaders(contentType()).and(host()),
+					requestHeaders(contentType(), host()),
 					requestParts(imageFile()),
 					requestParameters(title(), description()),
 					responseHeaders(contentType()),
-					responseFields(studyGroupId())));
+					responseFields(studyGroupIdField())));
+	}
+
+	@Test
+	@DisplayName("스터디 그룹에 가입신청을한다.")
+	void postApplyStudyGroup() throws Exception {
+		//given
+		StudyGroupIdResponse idResponse = new StudyGroupIdResponse(1L);
+
+		given(studyGroupService.applyStudyGroup(any())).willReturn(idResponse);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			RestDocumentationRequestBuilders.post("/api/v1/study-groups/{studyGroupId}",
+				idResponse.studyGroupId()).contentType(APPLICATION_JSON));
+
+		resultActions
+			.andExpectAll(
+				status().isOk(),
+				content().json(objectMapper.writeValueAsString(idResponse)))
+			.andDo(
+				document(COMMON_DOCS_NAME,
+					requestHeaders(contentType(), host()),
+					pathParameters(studyGroupIdPath()),
+					responseHeaders(contentType()),
+					responseFields(studyGroupIdField())));
 	}
 
 	private MultiValueMap<String, String> toCreateParams() {
@@ -132,10 +167,8 @@ class StudyGroupRestControllerTest extends TestConfig {
 			"image/png", "abcde".getBytes()).getBytes();
 	}
 
-	private List<HeaderDescriptor> contentType() {
-		return List.of(
-			headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입")
-		);
+	private HeaderDescriptor contentType() {
+		return headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입");
 	}
 
 	private HeaderDescriptor location() {
@@ -146,7 +179,11 @@ class StudyGroupRestControllerTest extends TestConfig {
 		return headerWithName(HttpHeaders.HOST).description("호스트");
 	}
 
-	private FieldDescriptor studyGroupId() {
+	private ParameterDescriptor studyGroupIdPath() {
+		return parameterWithName(STUDY_GROUP_ID.value()).description("스터디 그룹 아이디");
+	}
+
+	private FieldDescriptor studyGroupIdField() {
 		return fieldWithPath(STUDY_GROUP_ID.value()).type(NUMBER).description("스터디 그룹 아이디");
 	}
 

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +16,7 @@ import prgrms.project.stuti.domain.studygroup.model.StudyMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
 import prgrms.project.stuti.domain.studygroup.model.StudyPeriod;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
-import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
+import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
 
 class StudyMemberRepositoryTest extends RepositoryTestConfig {
 

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
@@ -72,5 +72,20 @@ class StudyMemberRepositoryTest extends RepositoryTestConfig {
 		//then
 		assertFalse(isLeader);
 	}
+
+	@Test
+	@DisplayName("스터디에 이미 가입신청을 했거나 가입이 된 멤버라면 true 를 반환한다.")
+	void testExistsByMemberIdAndStudyGroupId() {
+		//given
+		Long memberId = member.getId();
+		Long studyGroupId = studyGroup.getId();
+		studyMemberRepository.save(new StudyMember(StudyMemberRole.STUDY_MEMBER, member, studyGroup));
+
+		//when
+		boolean isExists = studyMemberRepository.existsByMemberIdAndStudyGroupId(memberId, studyGroupId);
+
+		//then
+		assertTrue(isExists);
+	}
 }
 

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
@@ -24,6 +24,7 @@ import prgrms.project.stuti.domain.studygroup.model.Region;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
 import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupApplyDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
@@ -107,6 +108,35 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 		assertEquals(updateDescription, studyGroup.getDescription());
 	}
 
+	@Test
+	@DisplayName("회원이 스터디 그룹에 가입신청을한다.")
+	void testApplyStudyGroup() {
+		//given
+		Long memberId = member2.getId();
+		Long studyGroupId = studyGroup.getId();
+		StudyGroupApplyDto applyDto = toApplyDto(memberId, studyGroupId);
+
+		//when
+		StudyGroupIdResponse idResponse = studyGroupService.applyStudyGroup(applyDto);
+
+		//then
+		assertNotNull(idResponse);
+		assertEquals(studyGroupId, idResponse.studyGroupId());
+	}
+
+	@Test
+	@DisplayName("이미 가입 했거나 가입신청을한 스터디 그룹에 가입신청을 한다면 예외가 발생한다.")
+	void testExistingStudyMember() {
+		//given
+		Long memberId = member2.getId();
+		Long studyGroupId = studyGroup.getId();
+		StudyGroupApplyDto applyDto = toApplyDto(memberId, studyGroupId);
+
+		//when, then
+		studyGroupService.applyStudyGroup(applyDto);
+		assertThrows(StudyGroupException.class, () -> studyGroupService.applyStudyGroup(applyDto));
+	}
+
 	private StudyGroupCreateDto toCreateDto(Long memberId) throws IOException {
 		return StudyGroupCreateDto
 			.builder()
@@ -134,6 +164,10 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 			.imageFile(imageFile)
 			.description(updateDescription)
 			.build();
+	}
+
+	private StudyGroupApplyDto toApplyDto(Long memberId, Long studyGroupId) {
+		return new StudyGroupApplyDto(memberId, studyGroupId);
 	}
 
 	private MultipartFile getMultipartFile() throws IOException {

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
@@ -23,7 +23,7 @@ import prgrms.project.stuti.domain.member.model.Mbti;
 import prgrms.project.stuti.domain.studygroup.model.Region;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
-import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
+import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupApplyDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
@@ -46,7 +46,7 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 	void setup() throws IOException {
 		StudyGroupCreateDto createDto = toCreateDto(member.getId());
 		StudyGroupIdResponse idResponse = studyGroupService.createStudyGroup(createDto);
-		this.studyGroup = studyGroupRepository.findById(idResponse.studyGroupId())
+		this.studyGroup = studyGroupRepository.findStudyGroupById(idResponse.studyGroupId())
 			.orElseThrow(() -> new IllegalArgumentException("failed to find studyGroup"));
 	}
 
@@ -58,7 +58,7 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 
 		//when
 		StudyGroupIdResponse idResponse = studyGroupService.createStudyGroup(createDto);
-		StudyGroup studyGroup = studyGroupRepository.findById(idResponse.studyGroupId())
+		StudyGroup studyGroup = studyGroupRepository.findStudyGroupById(idResponse.studyGroupId())
 			.orElseThrow(() -> StudyGroupException.notFoundStudyGroup(idResponse.studyGroupId()));
 
 		//then

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupServiceTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import javax.transaction.Transactional;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +27,7 @@ import prgrms.project.stuti.domain.studygroup.repository.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
+import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 import prgrms.project.stuti.global.error.exception.StudyGroupException;
 
 @Transactional


### PR DESCRIPTION
## ✅ PR 포인트
- 스터디 그룹 가입신청(참가신청) 기능을 구현.
- 소프트 딜리트 체크를 안하고 있던거 같아서 추가하였습니다.
- 시큐리티에 담겨오는 멤버 아이디와 PathVariable 의 스터디 그룹 아이디로 해당 스터디에 가입된 회원인지 찾고 있으면 예외를 없으면 가입을 진행시킵니다. 가입 시 스터디 멤버 역할은 APPLICANT 입니다.

## 🙉 고민했던 부분
- 스터디 멤버의 역할별로(신청자, 스터디멤버, 리더) 이미 가입된 스터디 멤버일 경우 신청하였습니다, 멤버입니다, 리더입니다 를 알려줘야 싶었는데 이부분은 오늘 프론트와 이야기해서 해결이 되었습니다.

## 🙋 질문
- Querydsl 레포지토리가 너무 많이 사용되는 느낌이 드는데 저도 강의만보고 실사용은 처음이라 헷갈리네요 🙉
