### PR TITLE
[FEATURE] 스터디 멤버 관리기능을 구현하라(스터디 신청 가입수락, 스터디 멤버 삭제)

### DIFF
--- a/src/main/docs/study-member.adoc
+++ b/src/main/docs/study-member.adoc
@@ -1,0 +1,9 @@
+== 스터디 멤버
+
+=== 스터디 멤버 가입수락
+operation::post-apply-study-group[snippets='http-request,request-headers,path-parameters,response-headers,response-fields,response-body']
+'''
+
+=== 스터디 멤버 삭제
+operation::delete-study-member[snippets='http-request,request-headers,path-parameters,response-headers']
+'''

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
@@ -49,14 +49,6 @@ public class StudyGroupRestController {
 		return ResponseEntity.ok(detailResponse);
 	}
 
-	@PostMapping("/{studyGroupId}")
-	public ResponseEntity<StudyGroupIdResponse> applyStudyGroup(@AuthenticationPrincipal Long memberId,
-		@PathVariable Long studyGroupId) {
-		StudyGroupIdResponse idResponse = studyGroupService.applyStudyGroup(memberId, studyGroupId);
-
-		return ResponseEntity.ok(idResponse);
-	}
-
 	@PatchMapping("/{studyGroupId}")
 	public ResponseEntity<StudyGroupIdResponse> updateStudyGroup(@AuthenticationPrincipal Long memberId,
 		@PathVariable Long studyGroupId, @Valid @ModelAttribute StudyGroupUpdateRequest updateRequest) {

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 
 import javax.validation.Valid;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,9 +20,9 @@ import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupCreateRequest;
 import prgrms.project.stuti.domain.studygroup.controller.dto.StudyGroupUpdateRequest;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupDetailResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupIdResponse;
-import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 
 @RestController
@@ -66,10 +67,10 @@ public class StudyGroupRestController {
 	}
 
 	@DeleteMapping("/{studyGroupId}")
-	public ResponseEntity<StudyGroupIdResponse> deleteStudyGroup(@AuthenticationPrincipal Long memberId,
+	public ResponseEntity<Void> deleteStudyGroup(@AuthenticationPrincipal Long memberId,
 		@PathVariable Long studyGroupId) {
-		StudyGroupIdResponse idResponse = studyGroupService.deleteStudyGroup(memberId, studyGroupId);
+		studyGroupService.deleteStudyGroup(memberId, studyGroupId);
 
-		return ResponseEntity.ok(idResponse);
+		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).build();
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestController.java
@@ -1,0 +1,29 @@
+package prgrms.project.stuti.domain.studygroup.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.studygroup.service.response.StudyMemberIdResponse;
+import prgrms.project.stuti.domain.studygroup.service.studymember.StudyMemberService;
+
+@RestController
+@RequestMapping("/api/v1/study-groups/{studyGroupId}/study-members")
+@RequiredArgsConstructor
+public class StudyMemberRestController {
+
+	private final StudyMemberService studyMemberService;
+
+	@PatchMapping("/{studyMemberId}")
+	public ResponseEntity<StudyMemberIdResponse> acceptRequestForJoin(@AuthenticationPrincipal Long memberId,
+		@PathVariable Long studyGroupId, @PathVariable Long studyMemberId) {
+		StudyMemberIdResponse idResponse = studyMemberService.acceptRequestForJoin(memberId, studyGroupId,
+			studyMemberId);
+
+		return ResponseEntity.ok(idResponse);
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestController.java
@@ -1,7 +1,9 @@
 package prgrms.project.stuti.domain.studygroup.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +27,13 @@ public class StudyMemberRestController {
 			studyMemberId);
 
 		return ResponseEntity.ok(idResponse);
+	}
+
+	@DeleteMapping(value = "/{studyMemberId}")
+	public ResponseEntity<Void> deleteStudyMember(@AuthenticationPrincipal Long memberId,
+		@PathVariable Long studyGroupId, @PathVariable Long studyMemberId) {
+		studyMemberService.deleteStudyMember(memberId, studyGroupId, studyMemberId);
+
+		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).build();
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestController.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +20,14 @@ import prgrms.project.stuti.domain.studygroup.service.studymember.StudyMemberSer
 public class StudyMemberRestController {
 
 	private final StudyMemberService studyMemberService;
+
+	@PostMapping
+	public ResponseEntity<StudyMemberIdResponse> applyForJoinStudyGroup(@AuthenticationPrincipal Long memberId,
+		@PathVariable Long studyGroupId) {
+		StudyMemberIdResponse idResponse = studyMemberService.applyForJoinStudyGroup(memberId, studyGroupId);
+
+		return ResponseEntity.ok(idResponse);
+	}
 
 	@PatchMapping("/{studyMemberId}")
 	public ResponseEntity<StudyMemberIdResponse> acceptRequestForJoin(@AuthenticationPrincipal Long memberId,

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/model/StudyMember.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/model/StudyMember.java
@@ -48,6 +48,10 @@ public class StudyMember extends BaseEntity {
 		this.studyGroup = studyGroup;
 	}
 
+	public void updateStudyMemberRole(StudyMemberRole studyMemberRole) {
+		this.studyMemberRole = studyMemberRole;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this,

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/CommonStudyGroupBooleanExpression.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/CommonStudyGroupBooleanExpression.java
@@ -29,7 +29,7 @@ public class CommonStudyGroupBooleanExpression {
 		return isEqualIdStudyGroup(studyGroupId).and(isNotDeletedStudyGroup());
 	}
 
-	private static BooleanExpression isNotDeletedStudyGroup() {
+	public static BooleanExpression isNotDeletedStudyGroup() {
 		return studyGroup.isDeleted.isFalse();
 	}
 

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepository.java
@@ -1,6 +1,12 @@
 package prgrms.project.stuti.domain.studygroup.repository.studymember;
 
+import java.util.Optional;
+
+import prgrms.project.stuti.domain.studygroup.model.StudyMember;
+
 public interface CustomStudyMemberRepository {
 
 	boolean isLeader(Long memberId, Long studyGroupId);
+
+	Optional<StudyMember> findStudyMemberById(Long studyMemberId);
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyMemberRepositoryImpl.java
@@ -5,9 +5,12 @@ import static prgrms.project.stuti.domain.studygroup.model.QStudyGroup.*;
 import static prgrms.project.stuti.domain.studygroup.model.QStudyMember.*;
 import static prgrms.project.stuti.domain.studygroup.repository.CommonStudyGroupBooleanExpression.*;
 
+import java.util.Optional;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.studygroup.model.StudyMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
 
 @RequiredArgsConstructor
@@ -27,5 +30,16 @@ public class CustomStudyMemberRepositoryImpl implements CustomStudyMemberReposit
 			.fetchFirst();
 
 		return result != null;
+	}
+
+	public Optional<StudyMember> findStudyMemberById(Long studyMemberId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(studyMember)
+				.join(studyMember.member, member)
+				.join(studyMember.studyGroup, studyGroup)
+				.where(studyMember.id.eq(studyMemberId), isNotDeletedMember(), isNotDeletedStudyGroup())
+				.fetchFirst()
+		);
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/response/StudyMemberIdResponse.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/response/StudyMemberIdResponse.java
@@ -1,0 +1,4 @@
+package prgrms.project.stuti.domain.studygroup.service.response;
+
+public record StudyMemberIdResponse(Long studyMemberId) {
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
@@ -19,9 +19,9 @@ import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRe
 import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyMemberRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupDetailDto;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupDetailResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupIdResponse;
-import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 import prgrms.project.stuti.global.error.exception.MemberException;
 import prgrms.project.stuti.global.error.exception.StudyGroupException;
 import prgrms.project.stuti.global.uploader.ImageUploader;
@@ -77,11 +77,9 @@ public class StudyGroupService {
 	}
 
 	@Transactional
-	public StudyGroupIdResponse deleteStudyGroup(Long memberId, Long studyGroupId) {
+	public void deleteStudyGroup(Long memberId, Long studyGroupId) {
 		validateLeader(memberId, studyGroupId);
 		updateToDeleted(studyGroupId);
-
-		return StudyGroupConverter.toStudyGroupIdResponse(studyGroupId);
 	}
 
 	private StudyGroup saveStudyGroup(StudyGroupCreateDto createDto, String imageUrl, String thumbnailUrl) {

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupService.java
@@ -69,14 +69,6 @@ public class StudyGroupService {
 	}
 
 	@Transactional
-	public StudyGroupIdResponse applyStudyGroup(Long memberId, Long studyGroupId) {
-		validateExistingStudyMember(memberId, studyGroupId);
-		saveStudyGroupApplicant(memberId, studyGroupId);
-
-		return StudyGroupConverter.toStudyGroupIdResponse(studyGroupId);
-	}
-
-	@Transactional
 	public void deleteStudyGroup(Long memberId, Long studyGroupId) {
 		validateLeader(memberId, studyGroupId);
 		updateToDeleted(studyGroupId);
@@ -97,13 +89,6 @@ public class StudyGroupService {
 		Member member = findMember(memberId);
 
 		studyMemberRepository.save(new StudyMember(StudyMemberRole.LEADER, member, studyGroup));
-	}
-
-	private void saveStudyGroupApplicant(Long memberId, Long studyGroupId) {
-		Member member = findMember(memberId);
-		StudyGroup studyGroup = findStudyGroup(studyGroupId);
-
-		studyMemberRepository.save(new StudyMember(StudyMemberRole.APPLICANT, member, studyGroup));
 	}
 
 	private void updateStudyGroupImage(MultipartFile imageFile, StudyGroup studyGroup) {
@@ -134,14 +119,6 @@ public class StudyGroupService {
 
 		if (!isLeader) {
 			throw StudyGroupException.notLeader(memberId, studyGroupId);
-		}
-	}
-
-	private void validateExistingStudyMember(Long memberId, Long studyGroupId) {
-		boolean isExists = studyMemberRepository.existsByMemberIdAndStudyGroupId(memberId, studyGroupId);
-
-		if (isExists) {
-			throw StudyGroupException.existingStudyMember(memberId, studyGroupId);
 		}
 	}
 

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberConverter.java
@@ -1,0 +1,13 @@
+package prgrms.project.stuti.domain.studygroup.service.studymember;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import prgrms.project.stuti.domain.studygroup.service.response.StudyMemberIdResponse;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StudyMemberConverter {
+
+	public static StudyMemberIdResponse toStudyMemberIdResponse(Long studyMemberId) {
+		return new StudyMemberIdResponse(studyMemberId);
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberService.java
@@ -25,6 +25,12 @@ public class StudyMemberService {
 		return StudyMemberConverter.toStudyMemberIdResponse(studyMemberId);
 	}
 
+	@Transactional
+	public void deleteStudyMember(Long memberId, Long studyGroupId, Long studyMemberId) {
+		validateLeader(memberId, studyGroupId);
+		studyMemberRepository.deleteById(studyMemberId);
+	}
+
 	private StudyMember findStudyMember(Long studyMemberId) {
 		return studyMemberRepository.findStudyMemberById(studyMemberId)
 			.orElseThrow(() -> StudyGroupException.notFoundStudyMember(studyMemberId));

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberService.java
@@ -1,0 +1,40 @@
+package prgrms.project.stuti.domain.studygroup.service.studymember;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.studygroup.model.StudyMember;
+import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
+import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyMemberRepository;
+import prgrms.project.stuti.domain.studygroup.service.response.StudyMemberIdResponse;
+import prgrms.project.stuti.global.error.exception.StudyGroupException;
+
+@Service
+@RequiredArgsConstructor
+public class StudyMemberService {
+
+	private final StudyMemberRepository studyMemberRepository;
+
+	@Transactional
+	public StudyMemberIdResponse acceptRequestForJoin(Long memberId, Long studyGroupId, Long studyMemberId) {
+		validateLeader(memberId, studyGroupId);
+		StudyMember studyMember = findStudyMember(studyMemberId);
+		studyMember.updateStudyMemberRole(StudyMemberRole.STUDY_MEMBER);
+
+		return StudyMemberConverter.toStudyMemberIdResponse(studyMemberId);
+	}
+
+	private StudyMember findStudyMember(Long studyMemberId) {
+		return studyMemberRepository.findStudyMemberById(studyMemberId)
+			.orElseThrow(() -> StudyGroupException.notFoundStudyMember(studyMemberId));
+	}
+
+	private void validateLeader(Long memberId, Long studyGroupId) {
+		boolean isLeader = studyMemberRepository.isLeader(memberId, studyGroupId);
+
+		if (!isLeader) {
+			throw StudyGroupException.notLeader(memberId, studyGroupId);
+		}
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberService.java
@@ -4,17 +4,34 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.member.model.Member;
+import prgrms.project.stuti.domain.member.repository.MemberRepository;
+import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.StudyMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
+import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyMemberRepository;
+import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyMemberIdResponse;
+import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupConverter;
+import prgrms.project.stuti.global.error.exception.MemberException;
 import prgrms.project.stuti.global.error.exception.StudyGroupException;
 
 @Service
 @RequiredArgsConstructor
 public class StudyMemberService {
 
+	private final MemberRepository memberRepository;
+	private final StudyGroupRepository studyGroupRepository;
 	private final StudyMemberRepository studyMemberRepository;
+
+	@Transactional
+	public StudyMemberIdResponse applyForJoinStudyGroup(Long memberId, Long studyGroupId) {
+		validateExistingStudyMember(memberId, studyGroupId);
+		Long studyMemberId = saveStudyGroupApplicant(memberId, studyGroupId);
+
+		return StudyMemberConverter.toStudyMemberIdResponse(studyMemberId);
+	}
 
 	@Transactional
 	public StudyMemberIdResponse acceptRequestForJoin(Long memberId, Long studyGroupId, Long studyMemberId) {
@@ -42,5 +59,29 @@ public class StudyMemberService {
 		if (!isLeader) {
 			throw StudyGroupException.notLeader(memberId, studyGroupId);
 		}
+	}
+
+	private void validateExistingStudyMember(Long memberId, Long studyGroupId) {
+		boolean isExists = studyMemberRepository.existsByMemberIdAndStudyGroupId(memberId, studyGroupId);
+
+		if (isExists) {
+			throw StudyGroupException.existingStudyMember(memberId, studyGroupId);
+		}
+	}
+
+	private Long saveStudyGroupApplicant(Long memberId, Long studyGroupId) {
+		Member member = findMember(memberId);
+		StudyGroup studyGroup = findStudyGroup(studyGroupId);
+
+		return studyMemberRepository.save(new StudyMember(StudyMemberRole.APPLICANT, member, studyGroup)).getId();
+	}
+
+	private Member findMember(Long memberId) {
+		return memberRepository.findMemberById(memberId).orElseThrow(() -> MemberException.notFoundMember(memberId));
+	}
+
+	private StudyGroup findStudyGroup(Long studyGroupId) {
+		return studyGroupRepository.findStudyGroupById(studyGroupId)
+			.orElseThrow(() -> StudyGroupException.notFoundStudyGroup(studyGroupId));
 	}
 }

--- a/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
+++ b/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	NOT_FOUND_STUDY_GROUP("SG002", "Not found study group", HttpStatus.NOT_FOUND),
 	NOT_LEADER("SG003", "Not leader", HttpStatus.BAD_REQUEST),
 	EXISTING_STUDY_MEMBER("SG004", "Existing study member", HttpStatus.BAD_REQUEST),
+	NOT_FOUND_STUDY_MEMBER("SG005", "Not found study member", HttpStatus.NOT_FOUND),
 
 	//file
 	EMPTY_FILE("F001", "Uploaded empty file", HttpStatus.BAD_REQUEST),

--- a/src/main/java/prgrms/project/stuti/global/error/exception/StudyGroupException.java
+++ b/src/main/java/prgrms/project/stuti/global/error/exception/StudyGroupException.java
@@ -34,4 +34,10 @@ public class StudyGroupException extends BusinessException {
 			MessageFormat.format(
 				"이미 존재하는 스터디 멤버입니다. (memberId: {0}, studyGroupId: {1})", memberId, studyGroupId));
 	}
+
+	public static StudyGroupException notFoundStudyMember(Long studyMemberId) {
+		return new StudyGroupException(ErrorCode.EXISTING_STUDY_MEMBER,
+			MessageFormat.format(
+				"스터디 멤버를 찾을 수 없습니다. (studyMemberId: {0})", studyMemberId));
+	}
 }

--- a/src/test/java/prgrms/project/stuti/config/RepositoryTestConfig.java
+++ b/src/test/java/prgrms/project/stuti/config/RepositoryTestConfig.java
@@ -23,6 +23,8 @@ public abstract class RepositoryTestConfig {
 
 	protected Member member;
 
+	protected Member otherMember;
+
 	@BeforeEach
 	void init() {
 		this.member = memberRepository.save(
@@ -36,6 +38,21 @@ public abstract class RepositoryTestConfig {
 				.blogUrl("blog321.com")
 				.mbti(Mbti.ENFJ)
 				.profileImageUrl("www.s3.com.321123")
+				.memberRole(MemberRole.ROLE_MEMBER)
+				.build()
+		);
+
+		this.otherMember = memberRepository.save(
+			Member
+				.builder()
+				.email("ttt123@gmail.com")
+				.nickName("nickname111")
+				.career(Career.JUNIOR)
+				.field(Field.ANDROID)
+				.githubUrl("github.com")
+				.blogUrl("blog.com")
+				.mbti(Mbti.ENFJ)
+				.profileImageUrl("www.image.com")
 				.memberRole(MemberRole.ROLE_MEMBER)
 				.build()
 		);

--- a/src/test/java/prgrms/project/stuti/config/ServiceTestConfig.java
+++ b/src/test/java/prgrms/project/stuti/config/ServiceTestConfig.java
@@ -3,6 +3,7 @@ package prgrms.project.stuti.config;
 import javax.transaction.Transactional;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,7 +17,6 @@ import prgrms.project.stuti.domain.member.repository.MemberRepository;
 
 @SpringBootTest
 @Transactional
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class ServiceTestConfig {
 
 	@Autowired
@@ -26,7 +26,7 @@ public abstract class ServiceTestConfig {
 
 	protected Member otherMember;
 
-	@BeforeAll
+	@BeforeEach
 	void init() {
 		this.member = memberRepository.save(
 			Member

--- a/src/test/java/prgrms/project/stuti/config/ServiceTestConfig.java
+++ b/src/test/java/prgrms/project/stuti/config/ServiceTestConfig.java
@@ -1,7 +1,8 @@
 package prgrms.project.stuti.config;
 
+import javax.transaction.Transactional;
+
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +15,7 @@ import prgrms.project.stuti.domain.member.model.MemberRole;
 import prgrms.project.stuti.domain.member.repository.MemberRepository;
 
 @SpringBootTest
+@Transactional
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class ServiceTestConfig {
 
@@ -22,7 +24,7 @@ public abstract class ServiceTestConfig {
 
 	protected Member member;
 
-	protected Member member2;
+	protected Member otherMember;
 
 	@BeforeAll
 	void init() {
@@ -41,7 +43,7 @@ public abstract class ServiceTestConfig {
 				.build()
 		);
 
-		this.member2 = memberRepository.save(
+		this.otherMember = memberRepository.save(
 			Member
 				.builder()
 				.email("test2@gmail.com")

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/CommonStudyDomainDescriptor.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/CommonStudyDomainDescriptor.java
@@ -1,2 +1,0 @@
-package prgrms.project.stuti.domain.studygroup.controller;public class CommonStudyDomainDescriptor {
-}

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/CommonStudyDomainDescriptor.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/CommonStudyDomainDescriptor.java
@@ -1,0 +1,2 @@
+package prgrms.project.stuti.domain.studygroup.controller;public class CommonStudyDomainDescriptor {
+}

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/CommonStudyGroupTestUtils.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/CommonStudyGroupTestUtils.java
@@ -1,0 +1,49 @@
+package prgrms.project.stuti.domain.studygroup.controller;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static prgrms.project.stuti.domain.studygroup.controller.CommonStudyGroupTestUtils.CommonField.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
+
+public class CommonStudyGroupTestUtils {
+
+	public static HeaderDescriptor contentType() {
+		return headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입");
+	}
+
+	public static HeaderDescriptor host() {
+		return headerWithName(HttpHeaders.HOST).description("호스트");
+	}
+
+	public static ParameterDescriptor studyGroupIdPath() {
+		return parameterWithName(STUDY_GROUP_ID.value()).description("스터디 그룹 아이디");
+	}
+
+	public static HeaderDescriptor contentLength() {
+		return headerWithName(CONTENT_LENGTH).description("컨텐츠 길이");
+	}
+
+	enum CommonField {
+		TITLE("title"), TOPIC("topic"), IS_ONLINE("isOnline"),
+		REGION("region"), PREFERRED_MBTIS("preferredMBTIs"), STUDY_MEMBER_ID("studyMemberId"),
+		NUMBER_OF_RECRUITS("numberOfRecruits"), START_DATE_TIME("startDateTime"),
+		END_DATE_TIME("endDateTime"), DESCRIPTION("description"), IMAGE_FILE("imageFile"),
+		STUDY_GROUP_ID("studyGroupId"), IMAGE_URL("imageUrl"), NUMBER_OF_MEMBERS("numberOfMembers"),
+		MEMBER_ID("memberId"), PROFILE_IMAGE_URL("profileImageUrl"), NICKNAME("nickname"), FIELD("field"),
+		CAREER("career"), MBTI("mbti");
+
+		private final String value;
+
+		CommonField(String value) {
+			this.value = value;
+		}
+
+		public String value() {
+			return this.value;
+		}
+	}
+}

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
@@ -170,12 +170,11 @@ class StudyGroupRestControllerTest extends TestConfig {
 	@DisplayName("스터디 그룹을 삭제한다.")
 	void deleteStudyGroup() throws Exception {
 		//given
-		StudyGroupIdResponse idResponse = new StudyGroupIdResponse(1L);
-		given(studyGroupService.deleteStudyGroup(any(), any())).willReturn(idResponse);
+		doNothing().when(studyGroupService).deleteStudyGroup(any(), any());
 
 		//when
 		ResultActions resultActions = mockMvc.perform(
-			delete("/api/v1/study-groups/{studyGroupId}", idResponse.studyGroupId())
+			delete("/api/v1/study-groups/{studyGroupId}", 1L)
 				.contentType(APPLICATION_JSON));
 
 		// then
@@ -187,8 +186,7 @@ class StudyGroupRestControllerTest extends TestConfig {
 				document(COMMON_DOCS_NAME,
 					requestHeaders(contentType(), host()),
 					pathParameters(studyGroupIdPath()),
-					responseHeaders(contentType()),
-					responseFields(studyGroupIdField())));
+					responseHeaders(contentType())));
 	}
 
 	private MultiValueMap<String, String> toCreateParams() {

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
@@ -10,7 +10,8 @@ import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static prgrms.project.stuti.domain.studygroup.controller.StudyGroupRestControllerTest.Field.*;
+import static prgrms.project.stuti.domain.studygroup.controller.CommonStudyGroupTestUtils.CommonField.*;
+import static prgrms.project.stuti.domain.studygroup.controller.CommonStudyGroupTestUtils.*;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -47,6 +48,7 @@ class StudyGroupRestControllerTest extends TestConfig {
 
 	@MockBean
 	private StudyGroupService studyGroupService;
+
 	private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
 	@Test
@@ -247,20 +249,8 @@ class StudyGroupRestControllerTest extends TestConfig {
 			"image/png", "test".getBytes()).getBytes();
 	}
 
-	private HeaderDescriptor contentType() {
-		return headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입");
-	}
-
 	private HeaderDescriptor location() {
 		return headerWithName(HttpHeaders.LOCATION).description("생성된 리소스 주소");
-	}
-
-	private HeaderDescriptor host() {
-		return headerWithName(HttpHeaders.HOST).description("호스트");
-	}
-
-	private ParameterDescriptor studyGroupIdPath() {
-		return parameterWithName(STUDY_GROUP_ID.value()).description("스터디 그룹 아이디");
 	}
 
 	private ParameterDescriptor title() {
@@ -308,31 +298,13 @@ class StudyGroupRestControllerTest extends TestConfig {
 
 	private List<FieldDescriptor> toLeaderFields() {
 		return List.of(
-			fieldWithPath("memberId").type(NUMBER).description("회원 아이디"),
-			fieldWithPath("profileImageUrl").type(STRING).description("프로필 이미지 url"),
-			fieldWithPath("nickname").type(STRING).description("닉네임"),
-			fieldWithPath("field").type(STRING).description("업무분야"),
-			fieldWithPath("career").type(STRING).description("개발경력"),
-			fieldWithPath("mbti").type(STRING).description("MBTI")
+			fieldWithPath(MEMBER_ID.value()).type(NUMBER).description("회원 아이디"),
+			fieldWithPath(PROFILE_IMAGE_URL.value()).type(STRING).description("프로필 이미지 url"),
+			fieldWithPath(NICKNAME.value()).type(STRING).description("닉네임"),
+			fieldWithPath(FIELD.value()).type(STRING).description("업무분야"),
+			fieldWithPath(CAREER.value()).type(STRING).description("개발경력"),
+			fieldWithPath(MBTI.value()).type(STRING).description("MBTI")
 		);
-	}
-
-	enum Field {
-		TITLE("title"), TOPIC("topic"), IS_ONLINE("isOnline"),
-		REGION("region"), PREFERRED_MBTIS("preferredMBTIs"),
-		NUMBER_OF_RECRUITS("numberOfRecruits"), START_DATE_TIME("startDateTime"),
-		END_DATE_TIME("endDateTime"), DESCRIPTION("description"), IMAGE_FILE("imageFile"),
-		STUDY_GROUP_ID("studyGroupId"), IMAGE_URL("imageUrl"), NUMBER_OF_MEMBERS("numberOfMembers");
-
-		private final String value;
-
-		Field(String value) {
-			this.value = value;
-		}
-
-		public String value() {
-			return this.value;
-		}
 	}
 }
 

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestControllerTest.java
@@ -143,30 +143,6 @@ class StudyGroupRestControllerTest extends TestConfig {
 	}
 
 	@Test
-	@DisplayName("스터디 그룹에 가입신청을한다.")
-	void postApplyStudyGroup() throws Exception {
-		//given
-		StudyGroupIdResponse idResponse = new StudyGroupIdResponse(1L);
-		given(studyGroupService.applyStudyGroup(any(), any())).willReturn(idResponse);
-
-		//when
-		ResultActions resultActions = mockMvc.perform(
-			post("/api/v1/study-groups/{studyGroupId}",
-				idResponse.studyGroupId()).contentType(APPLICATION_JSON));
-
-		resultActions
-			.andExpectAll(
-				status().isOk(),
-				content().json(objectMapper.writeValueAsString(idResponse)))
-			.andDo(
-				document(COMMON_DOCS_NAME,
-					requestHeaders(contentType(), host()),
-					pathParameters(studyGroupIdPath()),
-					responseHeaders(contentType()),
-					responseFields(studyGroupIdField())));
-	}
-
-	@Test
 	@DisplayName("스터디 그룹을 삭제한다.")
 	void deleteStudyGroup() throws Exception {
 		//given

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class StudyMemberRestControllerTest {
+  
+}

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
@@ -1,4 +1,76 @@
-import static org.junit.jupiter.api.Assertions.*;
-class StudyMemberRestControllerTest {
-  
+package prgrms.project.stuti.domain.studygroup.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static prgrms.project.stuti.domain.studygroup.controller.CommonStudyDomainDescriptor.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
+import org.springframework.test.web.servlet.ResultActions;
+
+import prgrms.project.stuti.config.TestConfig;
+import prgrms.project.stuti.domain.studygroup.service.response.StudyMemberIdResponse;
+import prgrms.project.stuti.domain.studygroup.service.studymember.StudyMemberService;
+
+@WebMvcTest(controllers = StudyMemberRestController.class)
+class StudyMemberRestControllerTest extends TestConfig {
+
+	@MockBean
+	private StudyMemberService studyMemberService;
+
+	@Test
+	@DisplayName("스터디 가입신청을 수락한다.")
+	void acceptRequestForJoin() throws Exception {
+		//given
+		StudyMemberIdResponse idResponse = toStudyMemberIdResponse(1L);
+		given(studyMemberService.acceptRequestForJoin(any(), any(), any())).willReturn(idResponse);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			patch("/api/v1/study-groups/{studyGroupId}/study-members/{studyMemberId}",
+				1L, idResponse.studyMemberId())
+				.contentType(APPLICATION_JSON));
+
+		//then
+		resultActions
+			.andExpectAll(
+				status().isOk(),
+				content().json(objectMapper.writeValueAsString(idResponse)),
+				content().contentType(APPLICATION_JSON))
+			.andDo(document(COMMON_DOCS_NAME,
+				requestHeaders(contentType(), host()),
+				pathParameters(studyGroupIdPath(), studyMemberIdPath()),
+				responseHeaders(contentType(), contentLength()),
+				responseFields(studyMemberIdField())
+			));
+	}
+
+	private StudyMemberIdResponse toStudyMemberIdResponse(Long studyMemberId) {
+		return new StudyMemberIdResponse(studyMemberId);
+	}
+
+	private ParameterDescriptor studyMemberIdPath() {
+		return parameterWithName("studyMemberId").description("스터디 멤버 아이디");
+	}
+
+	private HeaderDescriptor contentLength() {
+		return headerWithName(CONTENT_LENGTH).description("컨텐츠 길이");
+	}
+
+	private FieldDescriptor studyMemberIdField() {
+		return fieldWithPath("studyMemberId").type(NUMBER).description("스터디 멤버 아이디");
+	}
 }

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
@@ -1,7 +1,6 @@
 package prgrms.project.stuti.domain.studygroup.controller;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
@@ -10,13 +9,13 @@ import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static prgrms.project.stuti.domain.studygroup.controller.CommonStudyDomainDescriptor.*;
+import static prgrms.project.stuti.domain.studygroup.controller.CommonStudyGroupTestUtils.CommonField.*;
+import static prgrms.project.stuti.domain.studygroup.controller.CommonStudyGroupTestUtils.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 import org.springframework.test.web.servlet.ResultActions;
@@ -63,14 +62,10 @@ class StudyMemberRestControllerTest extends TestConfig {
 	}
 
 	private ParameterDescriptor studyMemberIdPath() {
-		return parameterWithName("studyMemberId").description("스터디 멤버 아이디");
-	}
-
-	private HeaderDescriptor contentLength() {
-		return headerWithName(CONTENT_LENGTH).description("컨텐츠 길이");
+		return parameterWithName(STUDY_MEMBER_ID.value()).description("스터디 멤버 아이디");
 	}
 
 	private FieldDescriptor studyMemberIdField() {
-		return fieldWithPath("studyMemberId").type(NUMBER).description("스터디 멤버 아이디");
+		return fieldWithPath(STUDY_MEMBER_ID.value()).type(NUMBER).description("스터디 멤버 아이디");
 	}
 }

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
@@ -30,17 +30,20 @@ class StudyMemberRestControllerTest extends TestConfig {
 	@MockBean
 	private StudyMemberService studyMemberService;
 
+	private final Long studyGroupId = 1L;
+	private final Long studyMemberId = 1L;
+
 	@Test
 	@DisplayName("스터디 가입신청을 수락한다.")
 	void acceptRequestForJoin() throws Exception {
 		//given
-		StudyMemberIdResponse idResponse = toStudyMemberIdResponse(1L);
+		StudyMemberIdResponse idResponse = toStudyMemberIdResponse(studyMemberId);
 		given(studyMemberService.acceptRequestForJoin(any(), any(), any())).willReturn(idResponse);
 
 		//when
 		ResultActions resultActions = mockMvc.perform(
 			patch("/api/v1/study-groups/{studyGroupId}/study-members/{studyMemberId}",
-				1L, idResponse.studyMemberId())
+				studyGroupId, studyMemberId)
 				.contentType(APPLICATION_JSON));
 
 		//then
@@ -53,8 +56,29 @@ class StudyMemberRestControllerTest extends TestConfig {
 				requestHeaders(contentType(), host()),
 				pathParameters(studyGroupIdPath(), studyMemberIdPath()),
 				responseHeaders(contentType(), contentLength()),
-				responseFields(studyMemberIdField())
-			));
+				responseFields(studyMemberIdField())));
+	}
+
+	@Test
+	@DisplayName("스터디 멤버를 삭제한다.")
+	void deleteStudyMember() throws Exception {
+		//given
+		willDoNothing().given(studyMemberService).deleteStudyMember(any(), any(), any());
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			delete("/api/v1/study-groups/{studyGroupId}/study-members/{studyMemberId}",
+				studyGroupId, studyMemberId).contentType(APPLICATION_JSON_VALUE));
+
+		//then
+		resultActions
+			.andExpectAll(
+				status().isOk(),
+				content().contentType(APPLICATION_JSON))
+			.andDo(document(COMMON_DOCS_NAME,
+				requestHeaders(contentType(), host()),
+				pathParameters(studyGroupIdPath(), studyMemberIdPath()),
+				responseHeaders(contentType())));
 	}
 
 	private StudyMemberIdResponse toStudyMemberIdResponse(Long studyMemberId) {

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/controller/StudyMemberRestControllerTest.java
@@ -34,6 +34,30 @@ class StudyMemberRestControllerTest extends TestConfig {
 	private final Long studyMemberId = 1L;
 
 	@Test
+	@DisplayName("스터디 그룹에 가입신청을한다.")
+	void postApplyStudyGroup() throws Exception {
+		//given
+		StudyMemberIdResponse idResponse = new StudyMemberIdResponse(1L);
+		given(studyMemberService.applyForJoinStudyGroup(any(), any())).willReturn(idResponse);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			post("/api/v1/study-groups/{studyGroupId}/study-members",
+				studyGroupId).contentType(APPLICATION_JSON));
+
+		resultActions
+			.andExpectAll(
+				status().isOk(),
+				content().json(objectMapper.writeValueAsString(idResponse)))
+			.andDo(
+				document(COMMON_DOCS_NAME,
+					requestHeaders(contentType(), host()),
+					pathParameters(studyGroupIdPath()),
+					responseHeaders(contentType()),
+					responseFields(studyMemberIdField())));
+	}
+
+	@Test
 	@DisplayName("스터디 가입신청을 수락한다.")
 	void acceptRequestForJoin() throws Exception {
 		//given

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyMemberRepositoryTest.java
@@ -3,6 +3,7 @@ package prgrms.project.stuti.domain.studygroup.repository.studymember;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +29,8 @@ class StudyMemberRepositoryTest extends RepositoryTestConfig {
 
 	private StudyGroup studyGroup;
 
+	private StudyMember studyMember;
+
 	@BeforeEach
 	void setup() {
 		this.studyGroup = studyGroupRepository.save(
@@ -44,6 +47,8 @@ class StudyMemberRepositoryTest extends RepositoryTestConfig {
 				.description("description")
 				.build()
 		);
+
+		this.studyMember = studyMemberRepository.save(new StudyMember(StudyMemberRole.LEADER, member, studyGroup));
 	}
 
 	@Test
@@ -63,10 +68,10 @@ class StudyMemberRepositoryTest extends RepositoryTestConfig {
 	@DisplayName("해당 스터디의 리더가 아니라면 false 를 반환한다.")
 	void testIsNotLeader() {
 		//given
-		studyMemberRepository.save(new StudyMember(StudyMemberRole.STUDY_MEMBER, member, studyGroup));
+		studyMemberRepository.save(new StudyMember(StudyMemberRole.STUDY_MEMBER, otherMember, studyGroup));
 
 		//when
-		boolean isLeader = studyMemberRepository.isLeader(member.getId(), studyGroup.getId());
+		boolean isLeader = studyMemberRepository.isLeader(otherMember.getId(), studyGroup.getId());
 
 		//then
 		assertFalse(isLeader);
@@ -85,6 +90,37 @@ class StudyMemberRepositoryTest extends RepositoryTestConfig {
 
 		//then
 		assertTrue(isExists);
+	}
+
+	@Test
+	@DisplayName("삭제되지 않은 스터디 그룹의 스터디 멤버를 찾아온다.")
+	void testFindStudyMemberById() {
+		//given
+		Long studyMemberId = studyMember.getId();
+
+		//when
+		Optional<StudyMember> studyMember = studyMemberRepository.findStudyMemberById(studyMemberId);
+
+		//then
+		assertTrue(studyMember.isPresent());
+		assertEquals(studyMemberId, studyMember.get().getId());
+	}
+
+	@Test
+	@DisplayName("참여하고 있는 스터디 그룹이 삭제되면 해당 스터디의 스터디 멤버를 찾을 수 없다.")
+	void testFindStudyMemberByIdWithDeletedStudyGroup() {
+		//given
+		StudyMember studyMember = studyMemberRepository.save(
+			new StudyMember(StudyMemberRole.LEADER, member, studyGroup));
+		StudyGroup studyGroup = studyMember.getStudyGroup();
+		studyGroup.delete();
+		Long studyMemberId = studyMember.getId();
+
+		//when
+		Optional<StudyMember> retrievedStudyMember = studyMemberRepository.findStudyMemberById(studyMemberId);
+
+		//then
+		assertTrue(retrievedStudyMember.isEmpty());
 	}
 }
 

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupServiceTest.java
@@ -123,33 +123,6 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 	}
 
 	@Test
-	@DisplayName("회원이 스터디 그룹에 가입신청을한다.")
-	void testApplyStudyGroup() {
-		//given
-		Long memberId = otherMember.getId();
-		Long studyGroupId = studyGroup.getId();
-
-		//when
-		StudyGroupIdResponse idResponse = studyGroupService.applyStudyGroup(memberId, studyGroupId);
-
-		//then
-		assertNotNull(idResponse);
-		assertEquals(studyGroupId, idResponse.studyGroupId());
-	}
-
-	@Test
-	@DisplayName("이미 가입 했거나 가입신청을한 스터디 그룹에 가입신청을 한다면 예외가 발생한다.")
-	void testExistingStudyMember() {
-		//given
-		Long memberId = otherMember.getId();
-		Long studyGroupId = studyGroup.getId();
-
-		//when, then
-		studyGroupService.applyStudyGroup(memberId, studyGroupId);
-		assertThrows(StudyGroupException.class, () -> studyGroupService.applyStudyGroup(memberId, studyGroupId));
-	}
-
-	@Test
 	@DisplayName("스터디 그룹을 삭제한다.")
 	void testDeleteStudyGroup() {
 		//given
@@ -170,7 +143,6 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 		//given
 		Long memberId = otherMember.getId();
 		Long studyGroupId = studyGroup.getId();
-		studyGroupService.applyStudyGroup(memberId, studyGroupId);
 
 		//when, then
 		assertThrows(StudyGroupException.class, () -> studyGroupService.deleteStudyGroup(memberId, studyGroupId));

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/studygroup/StudyGroupServiceTest.java
@@ -1,4 +1,4 @@
-package prgrms.project.stuti.domain.studygroup.service;
+package prgrms.project.stuti.domain.studygroup.service.studygroup;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -9,8 +9,6 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import javax.transaction.Transactional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,13 +24,11 @@ import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
 import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupCreateDto;
+import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupDetailResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupIdResponse;
-import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupUpdateDto;
-import prgrms.project.stuti.domain.studygroup.service.studygroup.StudyGroupService;
 import prgrms.project.stuti.global.error.exception.StudyGroupException;
 
-@Transactional
 class StudyGroupServiceTest extends ServiceTestConfig {
 
 	@Autowired
@@ -130,7 +126,7 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 	@DisplayName("회원이 스터디 그룹에 가입신청을한다.")
 	void testApplyStudyGroup() {
 		//given
-		Long memberId = member2.getId();
+		Long memberId = otherMember.getId();
 		Long studyGroupId = studyGroup.getId();
 
 		//when
@@ -145,7 +141,7 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 	@DisplayName("이미 가입 했거나 가입신청을한 스터디 그룹에 가입신청을 한다면 예외가 발생한다.")
 	void testExistingStudyMember() {
 		//given
-		Long memberId = member2.getId();
+		Long memberId = otherMember.getId();
 		Long studyGroupId = studyGroup.getId();
 
 		//when, then
@@ -156,7 +152,7 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 	@Test
 	@DisplayName("스터디 그룹을 삭제한다.")
 	void testDeleteStudyGroup() {
-	    //given
+		//given
 		Long memberId = member.getId();
 		Long studyGroupId = studyGroup.getId();
 
@@ -164,7 +160,7 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 		studyGroupService.deleteStudyGroup(memberId, studyGroupId);
 		Optional<StudyGroup> deletedStudyGroup = studyGroupRepository.findStudyGroupById(studyGroup.getId());
 
-	    //then
+		//then
 		assertTrue(deletedStudyGroup.isEmpty());
 	}
 
@@ -172,7 +168,7 @@ class StudyGroupServiceTest extends ServiceTestConfig {
 	@DisplayName("리더가 아닌 회원이 스터디 그룹을 삭제하려고 접근한다면 예외가 발생한다.")
 	void testNotLeaderAccessToDeleteStudyGroup() {
 		//given
-		Long memberId = member2.getId();
+		Long memberId = otherMember.getId();
 		Long studyGroupId = studyGroup.getId();
 		studyGroupService.applyStudyGroup(memberId, studyGroupId);
 

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberServiceTest.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ class StudyMemberServiceTest extends ServiceTestConfig {
 
 	private StudyMember studyMember;
 
-	@BeforeAll
+	@BeforeEach
 	void setup() {
 		this.studyGroup = studyGroupRepository.save(
 			StudyGroup

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/service/studymember/StudyMemberServiceTest.java
@@ -1,0 +1,74 @@
+package prgrms.project.stuti.domain.studygroup.service.studymember;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import prgrms.project.stuti.config.ServiceTestConfig;
+import prgrms.project.stuti.domain.studygroup.model.Region;
+import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
+import prgrms.project.stuti.domain.studygroup.model.StudyMember;
+import prgrms.project.stuti.domain.studygroup.model.StudyMemberRole;
+import prgrms.project.stuti.domain.studygroup.model.StudyPeriod;
+import prgrms.project.stuti.domain.studygroup.model.Topic;
+import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
+import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyMemberRepository;
+import prgrms.project.stuti.domain.studygroup.service.response.StudyMemberIdResponse;
+
+class StudyMemberServiceTest extends ServiceTestConfig {
+
+	@Autowired
+	private StudyMemberService studyMemberService;
+
+	@Autowired
+	private StudyGroupRepository studyGroupRepository;
+
+	@Autowired
+	private StudyMemberRepository studyMemberRepository;
+
+	private StudyGroup studyGroup;
+
+	@BeforeAll
+	void setup() {
+		this.studyGroup = studyGroupRepository.save(
+			StudyGroup
+				.builder()
+				.imageUrl("image")
+				.thumbnailUrl("thumbnail")
+				.title("title")
+				.topic(Topic.AI)
+				.isOnline(false)
+				.region(Region.SEOUL)
+				.numberOfRecruits(5)
+				.studyPeriod(new StudyPeriod(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusMonths(3)))
+				.description("this is new study group")
+				.build());
+
+		studyMemberRepository.save(new StudyMember(StudyMemberRole.LEADER, member, studyGroup));
+	}
+
+	@Test
+	@DisplayName("스터디 가입신청을 수락하면 스터디 멤버로 역할이 변경된다.")
+	void testAcceptRequestForJoin() {
+		//given
+		StudyMember applicant = studyMemberRepository.save(
+			new StudyMember(StudyMemberRole.APPLICANT, otherMember, studyGroup));
+
+		//when
+		StudyMemberIdResponse newStudyMember = studyMemberService.acceptRequestForJoin(member.getId(),
+			studyGroup.getId(), applicant.getId());
+		Optional<StudyMember> retrievedStudyMember = studyMemberRepository.findStudyMemberById(
+			newStudyMember.studyMemberId());
+
+		//then
+		assertEquals(applicant.getId(), newStudyMember.studyMemberId());
+		assertTrue(retrievedStudyMember.isPresent());
+		assertEquals(StudyMemberRole.STUDY_MEMBER, retrievedStudyMember.get().getStudyMemberRole());
+	}
+}


### PR DESCRIPTION
## ✅ PR 포인트
- 가입수락, 삭제 기능 두 가지를 한꺼번에 PR 하게되서 ㅈㅅㅈㅅ
- 기존에 스터디 가입신청 기능이 스터디 그룹 api 에 있었는데 가입신청 = 스터디 멤버 생성 이라고 생각해서 studymember api 로 이동하였습니다.

## 🙉 고민했던 부분
- 엔티티를 삭제하게 될 경우 해당 아이디의 엔티티가 삭제되었다는 의미로 바디에 id 를 리턴했었는데 프론트에서 굳이 정보가 필요 없는거 같아서 void 로 변경했습니다. 뭐가 더 좋은건지는 잘 모르곘네유
- 예외 메서드를 대문자로 바꿔보려고 했는데 경고창 나오길래 그냥 그대로 유지하였습니답

## 🙋 질문
- 놉
