### PR TITLE
[FEAT] 댓글 생성 기능을 구현하라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
@@ -1,0 +1,35 @@
+package prgrms.project.stuti.domain.feed.controller;
+
+import java.net.URI;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.feed.controller.dto.CommentRequest;
+import prgrms.project.stuti.domain.feed.service.CommentService;
+import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
+import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@PostMapping("/api/v1/posts/{postId}/comments")
+	public ResponseEntity<CommentIdResponse> createComment(@PathVariable Long postId,
+		@Valid @RequestBody CommentRequest commentRequest, @AuthenticationPrincipal Long memberId) {
+		CommentCreateDto commentCreateDto = CommentMapper.toCommentCreateDto(commentRequest, postId, memberId);
+		CommentIdResponse commentIdResponse = commentService.createComment(commentCreateDto);
+		URI uri = URI.create("/api/v1/posts/" + postId + "/comments/" + commentIdResponse.commentId());
+
+		return ResponseEntity.created(uri).body(commentIdResponse);
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.feed.controller.dto.CommentRequest;
 import prgrms.project.stuti.domain.feed.service.CommentService;
 import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
-import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+import prgrms.project.stuti.domain.feed.service.dto.CommentResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,12 +24,12 @@ public class CommentController {
 	private final CommentService commentService;
 
 	@PostMapping("/api/v1/posts/{postId}/comments")
-	public ResponseEntity<CommentIdResponse> createComment(@PathVariable Long postId,
+	public ResponseEntity<CommentResponse> createComment(@PathVariable Long postId,
 		@Valid @RequestBody CommentRequest commentRequest, @AuthenticationPrincipal Long memberId) {
 		CommentCreateDto commentCreateDto = CommentMapper.toCommentCreateDto(commentRequest, postId, memberId);
-		CommentIdResponse commentIdResponse = commentService.createComment(commentCreateDto);
-		URI uri = URI.create("/api/v1/posts/" + postId + "/comments/" + commentIdResponse.commentId());
+		CommentResponse commentResponse = commentService.createComment(commentCreateDto);
+		URI uri = URI.create("/api/v1/posts/" + postId + "/comments/" + commentResponse.postCommentId());
 
-		return ResponseEntity.created(uri).body(commentIdResponse);
+		return ResponseEntity.created(uri).body(commentResponse);
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentMapper.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentMapper.java
@@ -1,0 +1,16 @@
+package prgrms.project.stuti.domain.feed.controller;
+
+import prgrms.project.stuti.domain.feed.controller.dto.CommentRequest;
+import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
+
+public class CommentMapper {
+
+	public static CommentCreateDto toCommentCreateDto(CommentRequest commentRequest, Long postId, Long memberId) {
+		return CommentCreateDto.builder()
+			.memberId(memberId)
+			.postId(postId)
+			.parentId(commentRequest.parentId())
+			.contents(commentRequest.contents())
+			.build();
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/dto/CommentRequest.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/dto/CommentRequest.java
@@ -1,0 +1,11 @@
+package prgrms.project.stuti.domain.feed.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+
+public record CommentRequest(
+	Long parentId,
+
+	@NotBlank
+	String contents
+) {
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/repository/CommentRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package prgrms.project.stuti.domain.feed.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import prgrms.project.stuti.domain.feed.model.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentConverter.java
@@ -2,7 +2,7 @@ package prgrms.project.stuti.domain.feed.service;
 
 import prgrms.project.stuti.domain.feed.model.Comment;
 import prgrms.project.stuti.domain.feed.model.Feed;
-import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+import prgrms.project.stuti.domain.feed.service.dto.CommentResponse;
 
 public class CommentConverter {
 
@@ -10,7 +10,19 @@ public class CommentConverter {
 		return new Comment(contents, parentComment, feed.getMember(), feed);
 	}
 
-	public static CommentIdResponse toCommentIdResponse(Long commentId) {
-		return new CommentIdResponse(commentId);
+	public static CommentResponse toCommentResponse(Comment savedComment) {
+		Long parentId = null;
+		if (savedComment.getParent() != null) {
+			parentId = savedComment.getParent().getId();
+		}
+		return CommentResponse.builder()
+			.postCommentId(savedComment.getId())
+			.parentId(parentId)
+			.profileImageUrl(savedComment.getMember().getProfileImageUrl())
+			.memberId(savedComment.getMember().getId())
+			.nickname(savedComment.getMember().getNickName())
+			.contents(savedComment.getContent())
+			.createdAt(savedComment.getCreatedAt())
+			.build();
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentConverter.java
@@ -1,0 +1,16 @@
+package prgrms.project.stuti.domain.feed.service;
+
+import prgrms.project.stuti.domain.feed.model.Comment;
+import prgrms.project.stuti.domain.feed.model.Feed;
+import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+
+public class CommentConverter {
+
+	public static Comment toComment(String contents, Feed feed, Comment parentComment) {
+		return new Comment(contents, parentComment, feed.getMember(), feed);
+	}
+
+	public static CommentIdResponse toCommentIdResponse(Long commentId) {
+		return new CommentIdResponse(commentId);
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
@@ -34,6 +34,7 @@ public class CommentService {
 	}
 
 	private Comment getParentComment(Long parentCommentId) {
-		return commentRepository.findById(parentCommentId).orElseThrow(CommentException::PARENT_COMMENT_NOT_FOUND);
+		return commentRepository.findById(parentCommentId)
+			.orElseThrow(() -> CommentException.PARENT_COMMENT_NOT_FOUND(parentCommentId));
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
@@ -9,7 +9,7 @@ import prgrms.project.stuti.domain.feed.model.Feed;
 import prgrms.project.stuti.domain.feed.repository.CommentRepository;
 import prgrms.project.stuti.domain.feed.repository.FeedRepository;
 import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
-import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+import prgrms.project.stuti.domain.feed.service.dto.CommentResponse;
 import prgrms.project.stuti.global.error.exception.CommentException;
 import prgrms.project.stuti.global.error.exception.FeedException;
 
@@ -21,7 +21,7 @@ public class CommentService {
 	private final FeedRepository feedRepository;
 
 	@Transactional
-	public CommentIdResponse createComment(CommentCreateDto commentCreateDto) {
+	public CommentResponse createComment(CommentCreateDto commentCreateDto) {
 		Feed feed = feedRepository.findById(commentCreateDto.postId()).orElseThrow(FeedException::FEED_NOT_FOUND);
 		Comment parentComment = null;
 		if (commentCreateDto.parentId() != null) {
@@ -30,7 +30,7 @@ public class CommentService {
 		Comment newComment = CommentConverter.toComment(commentCreateDto.contents(), feed, parentComment);
 		Comment savedComment = commentRepository.save(newComment);
 
-		return CommentConverter.toCommentIdResponse(savedComment.getId());
+		return CommentConverter.toCommentResponse(savedComment);
 	}
 
 	private Comment getParentComment(Long parentCommentId) {

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
@@ -1,0 +1,39 @@
+package prgrms.project.stuti.domain.feed.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.feed.model.Comment;
+import prgrms.project.stuti.domain.feed.model.Feed;
+import prgrms.project.stuti.domain.feed.repository.CommentRepository;
+import prgrms.project.stuti.domain.feed.repository.FeedRepository;
+import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
+import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+import prgrms.project.stuti.global.error.exception.CommentException;
+import prgrms.project.stuti.global.error.exception.FeedException;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+	private final CommentRepository commentRepository;
+	private final FeedRepository feedRepository;
+
+	@Transactional
+	public CommentIdResponse createComment(CommentCreateDto commentCreateDto) {
+		Feed feed = feedRepository.findById(commentCreateDto.postId()).orElseThrow(FeedException::FEED_NOT_FOUND);
+		Comment parentComment = null;
+		if (commentCreateDto.parentId() != null) {
+			parentComment = getParentComment(commentCreateDto.parentId());
+		}
+		Comment newComment = CommentConverter.toComment(commentCreateDto.contents(), feed, parentComment);
+		Comment savedComment = commentRepository.save(newComment);
+
+		return CommentConverter.toCommentIdResponse(savedComment.getId());
+	}
+
+	private Comment getParentComment(Long parentCommentId) {
+		return commentRepository.findById(parentCommentId).orElseThrow(CommentException::PARENT_COMMENT_NOT_FOUND);
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentCreateDto.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentCreateDto.java
@@ -1,0 +1,14 @@
+package prgrms.project.stuti.domain.feed.service.dto;
+
+import lombok.Builder;
+
+public record CommentCreateDto(
+	Long memberId,
+	Long postId,
+	Long parentId,
+	String contents
+) {
+	@Builder
+	public CommentCreateDto{
+	}
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentIdResponse.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentIdResponse.java
@@ -1,0 +1,6 @@
+package prgrms.project.stuti.domain.feed.service.dto;
+
+public record CommentIdResponse(
+	Long commentId
+) {
+}

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentIdResponse.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentIdResponse.java
@@ -1,6 +1,0 @@
-package prgrms.project.stuti.domain.feed.service.dto;
-
-public record CommentIdResponse(
-	Long commentId
-) {
-}

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentResponse.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentResponse.java
@@ -1,0 +1,19 @@
+package prgrms.project.stuti.domain.feed.service.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+public record CommentResponse(
+	Long postCommentId,
+	Long parentId,
+	String profileImageUrl,
+	Long memberId,
+	String nickname,
+	String contents,
+	LocalDateTime createdAt
+) {
+	@Builder
+	public CommentResponse {
+	}
+}

--- a/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
+++ b/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
@@ -34,7 +34,10 @@ public enum ErrorCode {
 	REGISTERED_MEMBER("M006", "Member is already registered", HttpStatus.BAD_REQUEST),
 
 	//feed
-	FEED_NOT_FOUND("F001", "not exist post", HttpStatus.BAD_REQUEST);
+	FEED_NOT_FOUND("F001", "not exist post", HttpStatus.BAD_REQUEST),
+
+	//(feed)comment
+	PARENT_COMMENT_NOT_FOUND("FC001", "parent comment not exist", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/prgrms/project/stuti/global/error/exception/CommentException.java
+++ b/src/main/java/prgrms/project/stuti/global/error/exception/CommentException.java
@@ -1,0 +1,14 @@
+package prgrms.project.stuti.global.error.exception;
+
+import prgrms.project.stuti.global.error.dto.ErrorCode;
+
+public class CommentException extends BusinessException{
+
+	protected CommentException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	public static final CommentException PARENT_COMMENT_NOT_FOUND() {
+		throw new CommentException(ErrorCode.PARENT_COMMENT_NOT_FOUND, "원 댓글이 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/prgrms/project/stuti/global/error/exception/CommentException.java
+++ b/src/main/java/prgrms/project/stuti/global/error/exception/CommentException.java
@@ -1,5 +1,7 @@
 package prgrms.project.stuti.global.error.exception;
 
+import java.text.MessageFormat;
+
 import prgrms.project.stuti.global.error.dto.ErrorCode;
 
 public class CommentException extends BusinessException{
@@ -8,7 +10,8 @@ public class CommentException extends BusinessException{
 		super(errorCode, message);
 	}
 
-	public static final CommentException PARENT_COMMENT_NOT_FOUND() {
-		throw new CommentException(ErrorCode.PARENT_COMMENT_NOT_FOUND, "원 댓글이 존재하지 않습니다.");
+	public static final CommentException PARENT_COMMENT_NOT_FOUND(Long postCommentId) {
+		throw new CommentException(ErrorCode.PARENT_COMMENT_NOT_FOUND,
+			MessageFormat.format("상위 댓글이 존재하지 않습니다. ({0})", postCommentId));
 	}
 }

--- a/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
@@ -1,0 +1,47 @@
+package prgrms.project.stuti.domain.feed.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import prgrms.project.stuti.config.TestConfig;
+import prgrms.project.stuti.domain.feed.controller.dto.CommentRequest;
+import prgrms.project.stuti.domain.feed.service.CommentService;
+import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+
+@WebMvcTest(CommentController.class)
+class CommentControllerTest extends TestConfig {
+
+	@MockBean
+	private CommentService commentService;
+
+	@Test
+	@WithMockUser(username = "1", roles = {"ADMIN", "MEMBER"})
+	@DisplayName("댓글을 등록한다")
+	void testCreateComment() throws Exception {
+		CommentIdResponse commentIdResponse = new CommentIdResponse(1L);
+		String requestBody =
+			objectMapper.writeValueAsString(new CommentRequest(null, "테스트 댓글을 답니다."));
+
+		when(commentService.createComment(any())).thenReturn(commentIdResponse);
+
+		mockMvc.perform(post("/api/v1/posts/{postId}/comments", 1L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody)
+				.characterEncoding(StandardCharsets.UTF_8))
+			.andExpect(status().isCreated())
+			.andDo(print());
+	}
+
+}

--- a/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
@@ -1,12 +1,12 @@
 package prgrms.project.stuti.domain.feed.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +18,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import prgrms.project.stuti.config.TestConfig;
 import prgrms.project.stuti.domain.feed.controller.dto.CommentRequest;
 import prgrms.project.stuti.domain.feed.service.CommentService;
-import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+import prgrms.project.stuti.domain.feed.service.dto.CommentResponse;
 
 @WebMvcTest(CommentController.class)
 class CommentControllerTest extends TestConfig {
@@ -30,11 +30,19 @@ class CommentControllerTest extends TestConfig {
 	@WithMockUser(username = "1", roles = {"ADMIN", "MEMBER"})
 	@DisplayName("댓글을 등록한다")
 	void testCreateComment() throws Exception {
-		CommentIdResponse commentIdResponse = new CommentIdResponse(1L);
+		CommentResponse commentResponse = CommentResponse.builder()
+			.postCommentId(1L)
+			.parentId(null)
+			.profileImageUrl("www.test.prgrm/image.jpg")
+			.memberId(1L)
+			.nickname("testNickname")
+			.contents("새로운 댓글입니다.")
+			.createdAt(LocalDateTime.now())
+			.build();
 		String requestBody =
 			objectMapper.writeValueAsString(new CommentRequest(null, "테스트 댓글을 답니다."));
 
-		when(commentService.createComment(any())).thenReturn(commentIdResponse);
+		when(commentService.createComment(any())).thenReturn(commentResponse);
 
 		mockMvc.perform(post("/api/v1/posts/{postId}/comments", 1L)
 				.contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
@@ -1,0 +1,102 @@
+package prgrms.project.stuti.domain.feed.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import prgrms.project.stuti.config.ServiceTestConfig;
+import prgrms.project.stuti.domain.feed.model.Comment;
+import prgrms.project.stuti.domain.feed.model.Feed;
+import prgrms.project.stuti.domain.feed.repository.CommentRepository;
+import prgrms.project.stuti.domain.feed.repository.FeedRepository;
+import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
+import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+import prgrms.project.stuti.domain.member.model.Member;
+import prgrms.project.stuti.global.error.exception.FeedException;
+
+@SpringBootTest
+class CommentServiceTest extends ServiceTestConfig {
+
+	@Autowired
+	private CommentService commentService;
+
+	@Autowired
+	private FeedRepository feedRepository;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@AfterEach
+	void deleteAllComment() {
+		commentRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("댓글을 등록한다")
+	void testCreateParentComment() {
+		Feed post = createPost(member);
+
+		CommentCreateDto commentCreateDto = CommentCreateDto.builder()
+			.memberId(member.getId())
+			.postId(post.getId())
+			.parentId(null)
+			.contents("테스트 게시글 1번에 대한 댓글 1번")
+			.build();
+
+		CommentIdResponse commentIdResponse = commentService.createComment(commentCreateDto);
+		Comment savedComment = commentRepository.findById(commentIdResponse.commentId()).get();
+
+		assertThat(savedComment.getContent()).isEqualTo(commentCreateDto.contents());
+		assertThat(savedComment.getParent()).isNull();
+	}
+
+	@Test
+	@DisplayName("대댓글을 등록한다")
+	void testCreateChildComment() {
+		Feed post = createPost(member);
+		CommentCreateDto parentCommentCreateDto = CommentCreateDto.builder()
+			.memberId(member.getId())
+			.postId(post.getId())
+			.parentId(null)
+			.contents("테스트 게시글 1번에 대한 댓글")
+			.build();
+		CommentIdResponse parentCommentIdResponse = commentService.createComment(parentCommentCreateDto);
+
+		CommentCreateDto childCommentCreateDto = CommentCreateDto.builder()
+			.memberId(member.getId())
+			.postId(post.getId())
+			.parentId(parentCommentIdResponse.commentId())
+			.contents("테스트 게시글 1번에 대한 대댓글")
+			.build();
+		CommentIdResponse childCommentIdResponse = commentService.createComment(childCommentCreateDto);
+
+		Comment childComment = commentRepository.findById(childCommentIdResponse.commentId()).get();
+
+		assertThat(childComment.getContent()).isEqualTo(childCommentCreateDto.contents());
+		assertThat(childComment.getParent().getId()).isEqualTo(parentCommentIdResponse.commentId());
+
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 포스트에는 댓글을 달 수 없다")
+	void testCreateCommentWithNotExistPost() {
+		CommentCreateDto commentCreateDto = CommentCreateDto.builder()
+			.memberId(member.getId())
+			.postId(0L)
+			.parentId(null)
+			.contents("존재하지 않는 게시글의 댓글")
+			.build();
+
+		assertThrows(FeedException.class, () -> commentService.createComment(commentCreateDto));
+	}
+
+	private Feed createPost(Member member) {
+		Feed feed = new Feed("테스트 게시글 1번", member);
+		return feedRepository.save(feed);
+	}
+}

--- a/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
@@ -15,7 +15,7 @@ import prgrms.project.stuti.domain.feed.model.Feed;
 import prgrms.project.stuti.domain.feed.repository.CommentRepository;
 import prgrms.project.stuti.domain.feed.repository.FeedRepository;
 import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
-import prgrms.project.stuti.domain.feed.service.dto.CommentIdResponse;
+import prgrms.project.stuti.domain.feed.service.dto.CommentResponse;
 import prgrms.project.stuti.domain.member.model.Member;
 import prgrms.project.stuti.global.error.exception.FeedException;
 
@@ -48,8 +48,8 @@ class CommentServiceTest extends ServiceTestConfig {
 			.contents("테스트 게시글 1번에 대한 댓글 1번")
 			.build();
 
-		CommentIdResponse commentIdResponse = commentService.createComment(commentCreateDto);
-		Comment savedComment = commentRepository.findById(commentIdResponse.commentId()).get();
+		CommentResponse commentResponse = commentService.createComment(commentCreateDto);
+		Comment savedComment = commentRepository.findById(commentResponse.postCommentId()).get();
 
 		assertThat(savedComment.getContent()).isEqualTo(commentCreateDto.contents());
 		assertThat(savedComment.getParent()).isNull();
@@ -65,21 +65,20 @@ class CommentServiceTest extends ServiceTestConfig {
 			.parentId(null)
 			.contents("테스트 게시글 1번에 대한 댓글")
 			.build();
-		CommentIdResponse parentCommentIdResponse = commentService.createComment(parentCommentCreateDto);
+		CommentResponse parentCommentResponse = commentService.createComment(parentCommentCreateDto);
 
 		CommentCreateDto childCommentCreateDto = CommentCreateDto.builder()
 			.memberId(member.getId())
 			.postId(post.getId())
-			.parentId(parentCommentIdResponse.commentId())
+			.parentId(parentCommentResponse.postCommentId())
 			.contents("테스트 게시글 1번에 대한 대댓글")
 			.build();
-		CommentIdResponse childCommentIdResponse = commentService.createComment(childCommentCreateDto);
+		CommentResponse childCommentResponse = commentService.createComment(childCommentCreateDto);
 
-		Comment childComment = commentRepository.findById(childCommentIdResponse.commentId()).get();
+		Comment childComment = commentRepository.findById(childCommentResponse.postCommentId()).get();
 
 		assertThat(childComment.getContent()).isEqualTo(childCommentCreateDto.contents());
-		assertThat(childComment.getParent().getId()).isEqualTo(parentCommentIdResponse.commentId());
-
+		assertThat(childComment.getParent().getId()).isEqualTo(parentCommentResponse.postCommentId());
 	}
 
 	@Test


### PR DESCRIPTION
## ✅ PR 포인트
- 오늘 할당량 끗 !
- 댓글, 대댓글 등록 기능을 구현했습니다.
- 게시글이 없으면 댓글을 달 수 없고, 댓글이 없으면 대댓글을 달 수 없습니다.
## 🙉 고민했던 부분
- dto가 많이 생기면 패키지를 추가해야할 것 같습니다.
- 현재 저희가 댓글이면 parent를 null 값으로 지정하도록 했는데, 아무래도 null이 있는게 좀 걸리네요. null이 있으면 체크해줘야 할 것도 많을 것같고, 아직 조회쪽을 구현하지 않아서 그건 구현쪽 해보고 더 고민해봐야할 것 같습니다.
## 🙋 질문
