### PR TITLE
[FEAT] 댓글 수정, 삭제 기능을 구현하라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
@@ -4,8 +4,11 @@ import java.net.URI;
 
 import javax.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,5 +45,15 @@ public class CommentController {
 		CommentResponse commentResponse = commentService.changeComment(commentUpdateDto);
 
 		return ResponseEntity.ok().body(commentResponse);
+	}
+
+	@DeleteMapping("/api/v1/posts/{postId}/comments/{commentId}")
+	public ResponseEntity<Void> deleteComment(@PathVariable Long postId, @PathVariable Long commentId,
+		@AuthenticationPrincipal Long memberId) {
+		commentService.deleteComment(postId, commentId, memberId);
+		final HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+		return ResponseEntity.noContent().headers(httpHeaders).build();
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.feed.controller.dto.CommentRequest;
+import prgrms.project.stuti.domain.feed.service.dto.CommentUpdateDto;
 import prgrms.project.stuti.domain.feed.service.CommentService;
 import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
 import prgrms.project.stuti.domain.feed.service.dto.CommentResponse;
@@ -31,5 +33,14 @@ public class CommentController {
 		URI uri = URI.create("/api/v1/posts/" + postId + "/comments/" + commentResponse.postCommentId());
 
 		return ResponseEntity.created(uri).body(commentResponse);
+	}
+
+	@PatchMapping("/api/v1/posts/{postId}/comments/{commentId}")
+	public ResponseEntity<CommentResponse> changeComment(@PathVariable Long postId, @PathVariable Long commentId,
+		@Valid @RequestBody CommentRequest commentRequest, @AuthenticationPrincipal Long memberId) {
+		CommentUpdateDto commentUpdateDto = CommentMapper.toCommentUpdateDto(commentRequest, postId, commentId, memberId);
+		CommentResponse commentResponse = commentService.changeComment(commentUpdateDto);
+
+		return ResponseEntity.ok().body(commentResponse);
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentMapper.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/CommentMapper.java
@@ -1,6 +1,7 @@
 package prgrms.project.stuti.domain.feed.controller;
 
 import prgrms.project.stuti.domain.feed.controller.dto.CommentRequest;
+import prgrms.project.stuti.domain.feed.service.dto.CommentUpdateDto;
 import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
 
 public class CommentMapper {
@@ -9,6 +10,16 @@ public class CommentMapper {
 		return CommentCreateDto.builder()
 			.memberId(memberId)
 			.postId(postId)
+			.parentId(commentRequest.parentId())
+			.contents(commentRequest.contents())
+			.build();
+	}
+
+	public static CommentUpdateDto toCommentUpdateDto(CommentRequest commentRequest, Long postId, Long commentId, Long memberId) {
+		return CommentUpdateDto.builder()
+			.memberId(memberId)
+			.postId(postId)
+			.postCommentId(commentId)
 			.parentId(commentRequest.parentId())
 			.contents(commentRequest.contents())
 			.build();

--- a/src/main/java/prgrms/project/stuti/domain/feed/model/Comment.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/model/Comment.java
@@ -40,7 +40,7 @@ public class Comment extends BaseEntity {
 	@JoinColumn(name = "parent_id")
 	private Comment parent;
 
-	@OneToMany(mappedBy = "parent")
+	@OneToMany(mappedBy = "parent", orphanRemoval = true)
 	private final List<Comment> children = new ArrayList<>();
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/prgrms/project/stuti/domain/feed/model/Comment.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/model/Comment.java
@@ -59,6 +59,10 @@ public class Comment extends BaseEntity {
 		this.feed = feed;
 	}
 
+	public void changeContents(String content) {
+		this.content = content;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this,

--- a/src/main/java/prgrms/project/stuti/domain/feed/repository/CommentRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/repository/CommentRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import prgrms.project.stuti.domain.feed.model.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	void deleteAllByFeedId(Long postId);
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentConverter.java
@@ -22,7 +22,7 @@ public class CommentConverter {
 			.memberId(savedComment.getMember().getId())
 			.nickname(savedComment.getMember().getNickName())
 			.contents(savedComment.getContent())
-			.createdAt(savedComment.getCreatedAt())
+			.updatedAt(savedComment.getUpdatedAt())
 			.build();
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import prgrms.project.stuti.domain.feed.service.dto.CommentUpdateDto;
 import prgrms.project.stuti.domain.feed.model.Comment;
 import prgrms.project.stuti.domain.feed.model.Feed;
 import prgrms.project.stuti.domain.feed.repository.CommentRepository;
@@ -31,6 +32,18 @@ public class CommentService {
 		Comment savedComment = commentRepository.save(newComment);
 
 		return CommentConverter.toCommentResponse(savedComment);
+	}
+
+	@Transactional
+	public CommentResponse changeComment(CommentUpdateDto commentUpdateDto) {
+		Comment comment = commentRepository.findById(commentUpdateDto.postCommentId())
+			.orElseThrow(() -> CommentException.COMMENT_NOT_FOUND(commentUpdateDto.postCommentId()));
+		if(comment.getFeed() == null) { //추후 isdelete로 변경시 로직확인 필요, 대댓글인 경우 댓글 있는지 확인 필요
+			FeedException.FEED_NOT_FOUND();
+		}
+		comment.changeContents(commentUpdateDto.contents());
+
+		return CommentConverter.toCommentResponse(comment);
 	}
 
 	private Comment getParentComment(Long parentCommentId) {

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/CommentService.java
@@ -46,6 +46,13 @@ public class CommentService {
 		return CommentConverter.toCommentResponse(comment);
 	}
 
+	@Transactional
+	public void deleteComment(Long postId, Long commentId, Long memberId) {
+		feedRepository.findById(postId).orElseThrow(FeedException::FEED_NOT_FOUND);
+		commentRepository.findById(commentId).orElseThrow(() -> CommentException.COMMENT_NOT_FOUND(commentId));
+		commentRepository.deleteById(commentId);
+	}
+
 	private Comment getParentComment(Long parentCommentId) {
 		return commentRepository.findById(parentCommentId)
 			.orElseThrow(() -> CommentException.PARENT_COMMENT_NOT_FOUND(parentCommentId));

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/FeedService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/FeedService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.feed.model.Feed;
 import prgrms.project.stuti.domain.feed.model.FeedImage;
+import prgrms.project.stuti.domain.feed.repository.CommentRepository;
 import prgrms.project.stuti.domain.feed.repository.FeedImageRepository;
 import prgrms.project.stuti.domain.feed.repository.FeedRepository;
 import prgrms.project.stuti.domain.feed.service.dto.FeedResponse;
@@ -30,6 +31,7 @@ public class FeedService {
 	private final MemberRepository memberRepository;
 	private final ImageUploader imageUploader;
 	private final FeedImageRepository feedImageRepository;
+	private final CommentRepository commentRepository;
 
 	@Transactional
 	public PostIdResponse registerPost(PostCreateDto postDto) {
@@ -75,6 +77,7 @@ public class FeedService {
 	public void deletePost(Long postId) {
 		feedRepository.findById(postId).orElseThrow(FeedException::FEED_NOT_FOUND);
 		feedImageRepository.deleteByFeedId(postId);
+		commentRepository.deleteAllByFeedId(postId);
 		feedRepository.deleteById(postId);
 	}
 

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentResponse.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentResponse.java
@@ -11,7 +11,7 @@ public record CommentResponse(
 	Long memberId,
 	String nickname,
 	String contents,
-	LocalDateTime createdAt
+	LocalDateTime updatedAt
 ) {
 	@Builder
 	public CommentResponse {

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentUpdateDto.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/dto/CommentUpdateDto.java
@@ -1,0 +1,15 @@
+package prgrms.project.stuti.domain.feed.service.dto;
+
+import lombok.Builder;
+
+public record CommentUpdateDto(
+	Long memberId,
+	Long postId,
+	Long postCommentId,
+	Long parentId,
+	String contents
+) {
+	@Builder
+	public CommentUpdateDto {
+	}
+}

--- a/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
+++ b/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
 	FEED_NOT_FOUND("F001", "not exist post", HttpStatus.BAD_REQUEST),
 
 	//(feed)comment
-	PARENT_COMMENT_NOT_FOUND("FC001", "parent comment not exist", HttpStatus.BAD_REQUEST);
+	PARENT_COMMENT_NOT_FOUND("FC001", "parent comment not exist", HttpStatus.BAD_REQUEST),
+	COMMENT_NOT_FOUND("FC002", "not exist comment", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/prgrms/project/stuti/global/error/exception/CommentException.java
+++ b/src/main/java/prgrms/project/stuti/global/error/exception/CommentException.java
@@ -14,4 +14,9 @@ public class CommentException extends BusinessException{
 		throw new CommentException(ErrorCode.PARENT_COMMENT_NOT_FOUND,
 			MessageFormat.format("상위 댓글이 존재하지 않습니다. ({0})", postCommentId));
 	}
+
+	public static final CommentException COMMENT_NOT_FOUND(Long postCommentId) {
+		throw new CommentException(ErrorCode.COMMENT_NOT_FOUND,
+			MessageFormat.format("댓글이 존재하지 않습니다. ({0})", postCommentId));
+	}
 }

--- a/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
@@ -37,7 +37,7 @@ class CommentControllerTest extends TestConfig {
 			.memberId(1L)
 			.nickname("testNickname")
 			.contents("새로운 댓글입니다.")
-			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
 			.build();
 		String requestBody =
 			objectMapper.writeValueAsString(new CommentRequest(null, "테스트 댓글을 답니다."));

--- a/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
@@ -77,4 +77,15 @@ class CommentControllerTest extends TestConfig {
 			.andExpect(status().isOk())
 			.andDo(print());
 	}
+
+	@Test
+	@WithMockUser(username = "1", roles = {"ADMIN", "MEMBER"})
+	@DisplayName("댓글을 삭제한다")
+	void testDeleteComment() throws Exception {
+		doNothing().when(commentService).deleteComment(anyLong(), anyLong(), anyLong());
+
+		mockMvc.perform(delete("/api/v1/posts/{postId}/comments/{commentId}", 1L, 3L))
+			.andExpect(status().isNoContent())
+			.andDo(print());
+	}
 }

--- a/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/controller/CommentControllerTest.java
@@ -52,4 +52,29 @@ class CommentControllerTest extends TestConfig {
 			.andDo(print());
 	}
 
+	@Test
+	@WithMockUser(username = "1", roles = {"ADMIN", "MEMBER"})
+	@DisplayName("댓글을 수정한다.")
+	void testChangeComment() throws Exception {
+		CommentResponse commentResponse = CommentResponse.builder()
+			.postCommentId(1L)
+			.parentId(null)
+			.profileImageUrl("www.test.prgrm/image.jpg")
+			.memberId(1L)
+			.nickname("testNickname")
+			.contents("새로운 댓글입니다.")
+			.updatedAt(LocalDateTime.now())
+			.build();
+
+		String requestBody =
+			objectMapper.writeValueAsString(new CommentRequest(null, "댓글을 수정합니다."));
+
+		when(commentService.changeComment(any())).thenReturn(commentResponse);
+
+		mockMvc.perform(patch("/api/v1/posts/{postId}/comments/{commentId}", 1L, 3L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
 }

--- a/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
@@ -151,7 +151,7 @@ class CommentServiceTest extends ServiceTestConfig {
 		Feed post = createPost(member);
 		Comment parentComment = new Comment("댓글입니다.", null, member, post);
 		commentRepository.save(parentComment);
-		Comment childComment = new Comment("대댓글입니다.", parentComment, member2, post);
+		Comment childComment = new Comment("대댓글입니다.", parentComment, member, post);
 		commentRepository.save(childComment);
 
 		commentService.deleteComment(post.getId(), parentComment.getId(), member.getId());

--- a/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import prgrms.project.stuti.config.ServiceTestConfig;
+import prgrms.project.stuti.domain.feed.service.dto.CommentUpdateDto;
 import prgrms.project.stuti.domain.feed.model.Comment;
 import prgrms.project.stuti.domain.feed.model.Feed;
 import prgrms.project.stuti.domain.feed.repository.CommentRepository;
@@ -17,6 +18,7 @@ import prgrms.project.stuti.domain.feed.repository.FeedRepository;
 import prgrms.project.stuti.domain.feed.service.dto.CommentCreateDto;
 import prgrms.project.stuti.domain.feed.service.dto.CommentResponse;
 import prgrms.project.stuti.domain.member.model.Member;
+import prgrms.project.stuti.global.error.exception.CommentException;
 import prgrms.project.stuti.global.error.exception.FeedException;
 
 @SpringBootTest
@@ -92,6 +94,40 @@ class CommentServiceTest extends ServiceTestConfig {
 			.build();
 
 		assertThrows(FeedException.class, () -> commentService.createComment(commentCreateDto));
+	}
+
+	@Test
+	@DisplayName("댓글을 정상적으로 수정한다")
+	void testChangeComment() {
+		Feed post = createPost(member);
+		Comment comment = new Comment("댓글입니다.", null, member, post);
+		Comment savedComment = commentRepository.save(comment);
+		CommentUpdateDto commentUpdateDto = CommentUpdateDto.builder()
+			.memberId(member.getId())
+			.postId(post.getId())
+			.postCommentId(savedComment.getId())
+			.parentId(null)
+			.contents("수정된 댓글입니다.")
+			.build();
+
+		CommentResponse commentResponse = commentService.changeComment(commentUpdateDto);
+
+		assertThat(commentResponse.contents()).isEqualTo(commentUpdateDto.contents());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 댓글은 수정 할 수 없다")
+	void testChangeCommentWithNotExist() {
+		Feed post = createPost(member);
+		CommentUpdateDto commentUpdateDto = CommentUpdateDto.builder()
+			.memberId(member.getId())
+			.postId(post.getId())
+			.postCommentId(0L)
+			.parentId(null)
+			.contents("존재하지 않는 댓글에 대한 수정댓글입니다.")
+			.build();
+
+		assertThrows(CommentException.class, () -> commentService.changeComment(commentUpdateDto));
 	}
 
 	private Feed createPost(Member member) {

--- a/src/test/java/prgrms/project/stuti/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/service/FeedServiceTest.java
@@ -20,8 +20,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import prgrms.project.stuti.domain.feed.model.Comment;
 import prgrms.project.stuti.domain.feed.model.Feed;
 import prgrms.project.stuti.domain.feed.model.FeedImage;
+import prgrms.project.stuti.domain.feed.repository.CommentRepository;
 import prgrms.project.stuti.domain.feed.repository.FeedImageRepository;
 import prgrms.project.stuti.domain.feed.repository.FeedRepository;
 import prgrms.project.stuti.domain.feed.service.dto.FeedResponse;
@@ -49,6 +51,9 @@ class FeedServiceTest {
 
 	@Autowired
 	private FeedImageRepository feedImageRepository;
+
+	@Autowired
+	private CommentRepository commentRepository;
 
 	@Autowired
 	private FeedService feedService;
@@ -206,6 +211,20 @@ class FeedServiceTest {
 			.imageFile(testOriginalMultipartFile)
 			.build();
 		return feedService.registerPost(postDto);
+	}
+
+	@Test
+	@DisplayName("게시글 삭제시 게시글에 붙은 댓글도 전부 삭제처리한다.")
+	void testDeletePostWithComments() {
+		Feed feed = new Feed("울랄라 테스트 게시글", savedMember);
+		feedRepository.save(feed);
+		Comment comment = new Comment("댓글", null, savedMember, feed);
+		commentRepository.save(comment);
+
+		feedService.deletePost(feed.getId());
+		Optional<Comment> foundComment = commentRepository.findById(comment.getId());
+
+		assertThat(foundComment).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
## ✅ PR 포인트
- 빨리구현을 먼저로 했더니 코드가.....ㅠ.....
## 🙉 고민했던 부분
- 댓글 삭제시 member본인인지, post가/comment parent/comment가 유효한지 체크
- 위 중에 member 본인인지, comment parent가 유효한지는 확인하지 못했습니다. 추가되어야합니다.
- 추가로 게시글 삭제할때 외래키로 댓글 걸려있어서, 다 댓글 다 삭제해주는 로직을 넣어야할 것 같습니다. (추가완료)
## 🙋 질문
