### PR TITLE
[REFACTOR, FIX] 댓글 작성자 정보를 수정하고, 댓글 삭제시 댓글정보를 Response하라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/feed/controller/PostCommentController.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/controller/PostCommentController.java
@@ -52,11 +52,11 @@ public class PostCommentController {
 	}
 
 	@DeleteMapping("/api/v1/posts/{postId}/comments/{commentId}")
-	public ResponseEntity<Void> deleteComment(@PathVariable Long postId, @PathVariable Long commentId,
+	public ResponseEntity<PostCommentResponse> deleteComment(@PathVariable Long postId, @PathVariable Long commentId,
 		@AuthenticationPrincipal Long memberId) {
-		postCommentService.deleteComment(postId, commentId, memberId);
+		PostCommentResponse postCommentResponse = postCommentService.deleteComment(postId, commentId, memberId);
 
-		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).build();
+		return ResponseEntity.ok(postCommentResponse);
 	}
 
 	@GetMapping("/api/v1/posts/{postId}/comments")

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentConverter.java
@@ -9,12 +9,14 @@ import prgrms.project.stuti.domain.feed.service.dto.PostCommentChildContents;
 import prgrms.project.stuti.domain.feed.service.dto.PostCommentContentsResponse;
 import prgrms.project.stuti.domain.feed.service.dto.PostCommentGetDto;
 import prgrms.project.stuti.domain.feed.service.dto.PostCommentResponse;
+import prgrms.project.stuti.domain.member.model.Member;
 import prgrms.project.stuti.global.page.offset.PageResponse;
 
 public class PostCommentConverter {
 
-	public static PostComment toComment(String contents, Post post, PostComment parentPostComment) {
-		return new PostComment(contents, parentPostComment, post.getMember(), post);
+	public static PostComment toComment(String contents, Post post, PostComment parentPostComment,
+		Member commentWriteMember) {
+		return new PostComment(contents, parentPostComment, commentWriteMember, post);
 	}
 
 	public static PostCommentResponse toCommentResponse(PostComment savedPostComment) {

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentService.java
@@ -31,12 +31,11 @@ public class PostCommentService {
 
 	@Transactional
 	public PostCommentResponse createComment(PostCommentCreateDto postCommentCreateDto) {
-		Post post = postRepository.findById(postCommentCreateDto.postId()).orElseThrow(PostException::POST_NOT_FOUND);
-		Member foundMember = memberRepository.findById(postCommentCreateDto.memberId())
-			.orElseThrow(() -> MemberException.notFoundMember(postCommentCreateDto.memberId()));
+		Post post = getPostById(postCommentCreateDto.postId());
+		Member foundMember = getMemberById(postCommentCreateDto.memberId());
 		PostComment parentPostComment = null;
 		if (postCommentCreateDto.parentId() != null) {
-			parentPostComment = getParentComment(postCommentCreateDto.parentId());
+			parentPostComment = getCommentById(postCommentCreateDto.parentId());
 		}
 		PostComment newPostComment = PostCommentConverter.toComment(postCommentCreateDto.contents(), post,
 			parentPostComment, foundMember);
@@ -47,8 +46,8 @@ public class PostCommentService {
 
 	@Transactional
 	public PostCommentResponse changeComment(PostCommentUpdateDto postCommentUpdateDto) {
-		PostComment postComment = postCommentRepository.findById(postCommentUpdateDto.postCommentId())
-			.orElseThrow(() -> CommentException.COMMENT_NOT_FOUND(postCommentUpdateDto.postCommentId()));
+		PostComment postComment = getCommentById(postCommentUpdateDto.postCommentId());
+		validateEditMember(postComment, postCommentUpdateDto.memberId());
 		if (postComment.getPost() == null) { //추후 isdelete로 변경시 로직확인 필요, 대댓글인 경우 댓글 있는지 확인 필요
 			PostException.POST_NOT_FOUND();
 		}
@@ -59,33 +58,27 @@ public class PostCommentService {
 
 	@Transactional
 	public void deleteComment(Long postId, Long commentId, Long memberId) {
-		postRepository.findById(postId).orElseThrow(PostException::POST_NOT_FOUND);
-		PostComment foundPostComment = postCommentRepository.findById(commentId)
-			.orElseThrow(() -> CommentException.COMMENT_NOT_FOUND(commentId));
+		validatePostById(postId);
+		PostComment foundPostComment = getCommentById(commentId);
+		validateEditMember(foundPostComment, memberId);
+
 		deleteComments(foundPostComment);
 	}
 
 	@Transactional(readOnly = true)
 	public PageResponse<CommentParentContents> getPostComments(PostCommentGetDto postCommentGetDto) {
-		postRepository.findById(postCommentGetDto.postId()).orElseThrow(PostException::POST_NOT_FOUND);
+		getPostById(postCommentGetDto.postId());
 
-		return postCommentRepository.findAllByPostIdAndParentIdIsNUllWithNoOffset(
-			postCommentGetDto.postId(),
+		return postCommentRepository.findAllByPostIdAndParentIdIsNUllWithNoOffset(postCommentGetDto.postId(),
 			postCommentGetDto.lastCommentId(), postCommentGetDto.size());
 	}
 
 	@Transactional(readOnly = true)
 	public PostCommentContentsResponse getCommentContents(Long postId, Long commentId) {
-		postRepository.findById(postId).orElseThrow(PostException::POST_NOT_FOUND);
-		PostComment postComment = postCommentRepository.findById(commentId)
-			.orElseThrow(() -> CommentException.COMMENT_NOT_FOUND(commentId));
+		validatePostById(postId);
+		PostComment postComment = getCommentById(commentId);
 
 		return PostCommentConverter.toCommentContentsResponse(postComment);
-	}
-
-	private PostComment getParentComment(Long parentCommentId) {
-		return postCommentRepository.findById(parentCommentId)
-			.orElseThrow(() -> CommentException.PARENT_COMMENT_NOT_FOUND(parentCommentId));
 	}
 
 	private void deleteComments(PostComment deletePostComment) {
@@ -93,5 +86,30 @@ public class PostCommentService {
 			postCommentRepository.deleteAllByParentId(deletePostComment.getId());
 		}
 		postCommentRepository.delete(deletePostComment);
+	}
+
+	private PostComment getCommentById(Long parentCommentId) {
+		return postCommentRepository.findById(parentCommentId)
+			.orElseThrow(() -> CommentException.PARENT_COMMENT_NOT_FOUND(parentCommentId));
+	}
+
+	private Post getPostById(Long postId) {
+		return postRepository.findById(postId).orElseThrow(PostException::POST_NOT_FOUND);
+	}
+
+	private Member getMemberById(Long memberId) {
+		return memberRepository.findById(memberId).orElseThrow(() -> MemberException.notFoundMember(memberId));
+	}
+
+	private void validatePostById(Long postId) {
+		postRepository.findById(postId).orElseThrow(PostException::POST_NOT_FOUND);
+	}
+
+	private void validateEditMember(PostComment comment, Long editMemberId) {
+		Member commentEditor = getMemberById(editMemberId);
+		Member commentCreator = comment.getMember();
+		if (!commentEditor.getId().equals(commentCreator.getId())) {
+			PostException.INVALID_EDITOR();
+		}
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentService.java
@@ -57,12 +57,14 @@ public class PostCommentService {
 	}
 
 	@Transactional
-	public void deleteComment(Long postId, Long commentId, Long memberId) {
+	public PostCommentResponse deleteComment(Long postId, Long commentId, Long memberId) {
 		validatePostById(postId);
 		PostComment foundPostComment = getCommentById(commentId);
 		validateEditMember(foundPostComment, memberId);
 
 		deleteComments(foundPostComment);
+
+		return PostCommentConverter.toCommentResponse(foundPostComment);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentService.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/PostCommentService.java
@@ -14,7 +14,10 @@ import prgrms.project.stuti.domain.feed.service.dto.PostCommentGetDto;
 import prgrms.project.stuti.domain.feed.service.dto.CommentParentContents;
 import prgrms.project.stuti.domain.feed.service.dto.PostCommentResponse;
 import prgrms.project.stuti.domain.feed.service.dto.PostCommentUpdateDto;
+import prgrms.project.stuti.domain.member.model.Member;
+import prgrms.project.stuti.domain.member.repository.MemberRepository;
 import prgrms.project.stuti.global.error.exception.CommentException;
+import prgrms.project.stuti.global.error.exception.MemberException;
 import prgrms.project.stuti.global.error.exception.PostException;
 import prgrms.project.stuti.global.page.offset.PageResponse;
 
@@ -24,16 +27,19 @@ public class PostCommentService {
 
 	private final PostCommentRepository postCommentRepository;
 	private final PostRepository postRepository;
+	private final MemberRepository memberRepository;
 
 	@Transactional
 	public PostCommentResponse createComment(PostCommentCreateDto postCommentCreateDto) {
 		Post post = postRepository.findById(postCommentCreateDto.postId()).orElseThrow(PostException::POST_NOT_FOUND);
+		Member foundMember = memberRepository.findById(postCommentCreateDto.memberId())
+			.orElseThrow(() -> MemberException.notFoundMember(postCommentCreateDto.memberId()));
 		PostComment parentPostComment = null;
 		if (postCommentCreateDto.parentId() != null) {
 			parentPostComment = getParentComment(postCommentCreateDto.parentId());
 		}
 		PostComment newPostComment = PostCommentConverter.toComment(postCommentCreateDto.contents(), post,
-			parentPostComment);
+			parentPostComment, foundMember);
 		PostComment savedPostComment = postCommentRepository.save(newPostComment);
 
 		return PostCommentConverter.toCommentResponse(savedPostComment);

--- a/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
+++ b/src/main/java/prgrms/project/stuti/global/error/dto/ErrorCode.java
@@ -42,11 +42,12 @@ public enum ErrorCode {
 	POST_NOT_FOUND("P001", "not exist post", HttpStatus.BAD_REQUEST),
 	POST_LIKE_DUPLICATED("P002", "already liked this post", HttpStatus.BAD_REQUEST),
 	NOT_FOUND_POST_LIKE("P003","not found feed like", HttpStatus.BAD_REQUEST),
+	INVALID_EDITOR("P004", "editor is not same to creator", HttpStatus.BAD_REQUEST),
 
 	//post comment
 	PARENT_POST_COMMENT_NOT_FOUND("PC001", "parent comment not exist", HttpStatus.BAD_REQUEST),
 	POST_COMMENT_NOT_FOUND("PC002", "not exist comment", HttpStatus.BAD_REQUEST),
-
+	
 	// Token Expiration
 	ACCESS_TOKEN_EXPIRATION("T001", "Access token is expired", HttpStatus.BAD_REQUEST),
 	REFRESH_TOKEN_EXPIRATION("T002", "Refresh token is expired", HttpStatus.BAD_REQUEST);

--- a/src/main/java/prgrms/project/stuti/global/error/exception/PostException.java
+++ b/src/main/java/prgrms/project/stuti/global/error/exception/PostException.java
@@ -19,4 +19,8 @@ public class PostException extends BusinessException{
 	public static final PostException NOT_FOUND_POST_LIKE() {
 		throw new PostException(ErrorCode.NOT_FOUND_POST_LIKE, "존재하지 않는 좋아요 입니다.");
 	}
+
+	public static final PostException INVALID_EDITOR() {
+		throw new PostException(ErrorCode.INVALID_EDITOR, "작성자와 수정자가 다릅니다.");
+	}
 }

--- a/src/test/java/prgrms/project/stuti/domain/feed/controller/PostCommentControllerTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/controller/PostCommentControllerTest.java
@@ -1,7 +1,7 @@
 package prgrms.project.stuti.domain.feed.controller;
 
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -87,9 +87,21 @@ class PostCommentControllerTest extends TestConfig {
 	@WithMockUser(username = "1", roles = {"ADMIN", "MEMBER"})
 	@DisplayName("댓글을 삭제한다")
 	void testDeleteComment() throws Exception {
-		doNothing().when(postCommentService).deleteComment(anyLong(), anyLong(), anyLong());
+		PostCommentResponse postCommentResponse = PostCommentResponse.builder()
+			.postCommentId(1L)
+			.parentId(null)
+			.profileImageUrl("www.test.prgrm/image.jpg")
+			.memberId(1L)
+			.nickname("testNickname")
+			.contents("새로운 댓글입니다.")
+			.updatedAt(LocalDateTime.now())
+			.build();
 
-		mockMvc.perform(delete("/api/v1/posts/{postId}/comments/{commentId}", 1L, 3L))
+		when(postCommentService.deleteComment(anyLong(), anyLong(), anyLong()))
+			.thenReturn(postCommentResponse);
+
+		mockMvc.perform(delete("/api/v1/posts/{postId}/comments/{commentId}", 1L, 1L)
+				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andDo(print());
 	}


### PR DESCRIPTION
## ✅ PR 포인트
- (FIX) 댓글 생성시 댓글생성한 사람에 게시글 생성자를 넣고있었습니다.. 댓글작성한 사람이 들어가도록 수정했습니다.
- (REFACTOR) 댓글 삭제시 아무것도 리턴하고 있지 않았는데, 프론트에서 리턴값을 추가해달라고 요청받아 수정합니다.
## 🙉 고민했던 부분


에러너무 많고... 저 테스트코드 왜 작성했는지 모르겠고.... 테스트코드의 중요성을 몸소 깨닫게 되네요..
## 🙋 질문
