### PR TITLE
[REFACTOR] 응답 필드 시간 한국시간 기준으로 변경, 스터디 문의대댓글 정렬 오름차순으로 변경, 스터디 리더도 스터디 멤버 리스트에 포함시켜라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studyquestion/CustomStudyGroupQuestionRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studyquestion/CustomStudyGroupQuestionRepositoryImpl.java
@@ -40,7 +40,7 @@ public class CustomStudyGroupQuestionRepositoryImpl implements CustomStudyGroupQ
 				parentIdIsNull(true),
 				equalStudyGroup(pageDto.studyGroupId()),
 				lessThanLastStudyGroupQuestionId(pageDto.lastStudyGroupQuestionId()))
-			.orderBy(studyGroupQuestionIdDesc())
+			.orderBy(studyGroupQuestion.id.desc())
 			.limit(pageDto.size() + NumberUtils.LONG_ONE)
 			.fetch();
 
@@ -62,7 +62,7 @@ public class CustomStudyGroupQuestionRepositoryImpl implements CustomStudyGroupQ
 			.join(studyGroupQuestion.member, member)
 			.join(studyGroupQuestion.studyGroup, studyGroup)
 			.where(parentIdIsNull(false), studyGroupQuestion.parent.id.in(parentIds))
-			.orderBy(studyGroupQuestionIdDesc())
+			.orderBy(studyGroupQuestion.id.asc())
 			.fetch();
 
 		Long totalElements = jpaQueryFactory
@@ -81,9 +81,5 @@ public class CustomStudyGroupQuestionRepositoryImpl implements CustomStudyGroupQ
 
 	private BooleanExpression lessThanLastStudyGroupQuestionId(Long lastStudyGroupQuestionId) {
 		return lastStudyGroupQuestionId == null ? null : studyGroupQuestion.id.lt(lastStudyGroupQuestionId);
-	}
-
-	private OrderSpecifier<Long> studyGroupQuestionIdDesc() {
-		return studyGroupQuestion.id.desc();
 	}
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupMemberConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupMemberConverter.java
@@ -23,16 +23,17 @@ public class StudyGroupMemberConverter {
 	}
 
 	public static StudyGroupMembersResponse toStudyGroupMembersResponse(List<StudyGroupMember> studyGroupMembers) {
-		Map<StudyGroupMemberRole, List<StudyGroupMember>> studyGroupMemberMap = studyGroupMembers
+		Map<Boolean, List<StudyGroupMember>> studyGroupMembersMap = studyGroupMembers
 			.stream()
-			.collect(Collectors.groupingBy(StudyGroupMember::getStudyGroupMemberRole));
+			.collect(Collectors.partitioningBy(
+				studyGroupMember ->
+					studyGroupMember.getStudyGroupMemberRole().equals(StudyGroupMemberRole.STUDY_APPLICANT)));
 
-		StudyGroupMember studyLeader = studyGroupMemberMap.get(StudyGroupMemberRole.STUDY_LEADER).get(0);
-		List<StudyGroupMember> studyMembers =
-			studyGroupMemberMap.getOrDefault(StudyGroupMemberRole.STUDY_MEMBER, Collections.emptyList());
-		List<StudyGroupMember> studyApplicants =
-			studyGroupMemberMap.getOrDefault(StudyGroupMemberRole.STUDY_APPLICANT, Collections.emptyList());
-		StudyGroup studyGroup = studyLeader.getStudyGroup();
+		List<StudyGroupMember> studyMembers = studyGroupMembersMap.get(false);
+		StudyGroupMember studyGroupMember = studyMembers.get(0);
+		StudyGroup studyGroup = studyGroupMember.getStudyGroup();
+
+		List<StudyGroupMember> studyApplicants = studyGroupMembersMap.get(true);
 
 		return StudyGroupMembersResponse
 			.builder()

--- a/src/main/java/prgrms/project/stuti/global/config/JsonDateTimeFormatConfig.java
+++ b/src/main/java/prgrms/project/stuti/global/config/JsonDateTimeFormatConfig.java
@@ -20,7 +20,7 @@ public class JsonDateTimeFormatConfig {
 	@Bean
 	public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
 		return jacksonObjectMapperBuilder -> jacksonObjectMapperBuilder
-			.timeZone(TimeZone.getTimeZone("UTC"))
+			.timeZone(TimeZone.getTimeZone("Asia/Seoul"))
 			.simpleDateFormat(DATE_FORMAT)
 			.serializers(new LocalDateSerializer(LOCAL_DATE_FORMATTER))
 			.serializers(new LocalDateTimeSerializer(LOCAL_DATE_TIME_FORMATTER))


### PR DESCRIPTION
## ✅ PR 포인트
- 응답 필드 시간 한국시간 기준으로 변경, 스터디 문의대댓글 정렬 오름차순으로 변경, 스터디 리더도 스터디 멤버 리스트에 포함시켜라

## 🙉 고민했던 부분

## 🙋 질문
