### PR TITLE
[FIX] 대댓글 중복 select 문제를 해결하라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/feed/model/PostComment.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/model/PostComment.java
@@ -63,12 +63,6 @@ public class PostComment extends BaseEntity {
 		this.content = content;
 	}
 
-	public List<PostComment> findChildren(List<PostComment> children) {
-		this.children.addAll(children);
-
-		return this.children;
-	}
-
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this,

--- a/src/main/java/prgrms/project/stuti/domain/feed/repository/PostCommentCustomRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/repository/PostCommentCustomRepositoryImpl.java
@@ -45,11 +45,6 @@ public class PostCommentCustomRepositoryImpl implements PostCommentCustomReposit
 			hasNext = hasNext(postId, lastCalledComment);
 		}
 
-		for (PostComment postComment : postComments) {
-			List<PostComment> childPostComments = findByParentId(postComment.getId());
-			postComment.findChildren(childPostComments);
-		}
-
 		return PostCommentConverter.toCommentResponse(postComments, hasNext, totalParentComments);
 	}
 
@@ -68,11 +63,5 @@ public class PostCommentCustomRepositoryImpl implements PostCommentCustomReposit
 			.fetch();
 
 		return !postComments.isEmpty();
-	}
-
-	private List<PostComment> findByParentId(Long parentId) {
-		return jpaQueryFactory.selectFrom(postComment)
-			.where(postComment.parent.id.eq(parentId))
-			.fetch();
 	}
 }


### PR DESCRIPTION
## ✅ PR 포인트
- 대댓글을 중복으로 select 해오던것을 한번만 가져오도록 수정합니다.
## 🙉 고민했던 부분
- 현재 테스트가 정상으로 돌아가지 않아요.
- 연관관계를 실제 코드에서는 정상으로 가져오는데.. 테스트에선 가져오지 못해요 ㅠㅠ 뭐가 문제일까요...
  우선 구현이 먼저라 테스트코드 통과를 못했는데..올립니다.
## 🙋 질문
