### PR TITLE
[FIX] 게시글 조회시 이미지 URL을 불러오도록 수정하라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/feed/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/repository/PostCustomRepositoryImpl.java
@@ -41,9 +41,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 			.select(post, postImage)
 			.from(post)
 			.leftJoin(postImage).on(post.id.eq(postImage.post.id))
-			.leftJoin(member).on(post.member.id.eq(member.id))
 			.where(dynamicLtId)
-			.orderBy(postImage.id.desc())
+			.orderBy(post.id.desc())
 			.limit(size)
 			.fetch();
 
@@ -56,7 +55,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 				.mbti(tuple.get(post).getMember().getMbti())
 				.profileImageUrl(tuple.get(post).getMember().getProfileImageUrl())
 				.contents(tuple.get(post).getContent())
-				.postImageUrl(tuple.get(postImage.imageUrl))
+				.postImageUrl(tuple.get(postImage).getImageUrl())
 				.updatedAt(tuple.get(post).getUpdatedAt())
 				.likedMembers(findAllLikedMembers(tuple.get(post).getId()))
 				.totalPostComments(getTotalPostComments(tuple.get(post).getId()))

--- a/src/test/java/prgrms/project/stuti/domain/feed/service/PostServiceTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/feed/service/PostServiceTest.java
@@ -153,7 +153,7 @@ class PostServiceTest {
 	}
 
 	@Test
-	@DisplayName("전체 포스트리스트 첫 조회시(lastPostId가 null일 때) 페이징 조회한다")
+	@DisplayName("전체 포스트리스트 첫 조회시(lastPostId가 null일 때) 페이징 조회한다- 이미지 조회 추가")
 	void testGetAllPostsWhenLastPostIdIsNull() {
 		for (int i = 0; i < 10; i++) {
 			Post post = new Post("게시글" + i, savedMember);
@@ -167,6 +167,7 @@ class PostServiceTest {
 		assertThat(allPosts.posts()).hasSize(2);
 		assertThat(allPosts.posts().get(0).contents()).isEqualTo("게시글9");
 		assertThat(allPosts.hasNext()).isTrue();
+		assertThat(allPosts.posts().get(0).postImageUrl()).isEqualTo("9test.jpg");
 	}
 
 	@Test


### PR DESCRIPTION
## ✅ PR 포인트
- 이미지 URL을 null로 조회하고 있었던 오류를 수정합니다. 
- 현재 이미지를 저장하지 않아도 공백으로 저장하고있기에 가져올 수 있습니다. 하지만 저장하지 않는것으로 변경하면.. 로직이 수정되어야합니다.
  - querydsl에 대해 잘 모르고 사용하니 문제이네요..
## 🙉 고민했던 부분

## 🙋 질문
