### PR TITLE
[FIX] 이미지가 없을경우 NPE를 방지하며 빈스트링을 보내주도록 수정하라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/feed/service/PostConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/feed/service/PostConverter.java
@@ -27,12 +27,16 @@ public class PostConverter {
 			.memberId(member.getId())
 			.nickname(member.getNickName())
 			.mbti(member.getMbti())
-			.profileImageUrl(member.getProfileImageUrl())
+			.profileImageUrl(insertEmptyStringIfImageIsNull(member.getProfileImageUrl()))
 			.contents(post.getContent())
 			.postImageUrl(postImage.getImageUrl())
 			.updatedAt(post.getUpdatedAt())
 			.totalPostComments(totalPostComments)
 			.likedMembers(likedMembers)
 			.build();
+	}
+
+	private static String insertEmptyStringIfImageIsNull(String imageUrl) {
+		return imageUrl == null ? "" : imageUrl;
 	}
 }


### PR DESCRIPTION
## ✅ PR 포인트
- 생성시에는 이미지가 없는경우에도 항상 emptyString을 넣어줍니다. 그런데 최초 DB에 마이그한 값이 이미지가 없는 게시글인 경우가 있습니다. 이런경우 이미지를 가져올 때 NPE가 났습니다. (querydsl에서 null 객체 참조). db마이그를 생각하지 않더라도 NPE는 발생하지 않아야하므로 수정처리 하였습니다. 추가로 이미지에대해서 null인경우 (게시글이미지, 프로필이미지) emptyString을 반환하도록 수정합니다.
## 🙉 고민했던 부분

## 🙋 질문
