### PR TITLE
[REFACTOR] 스터디 그룹 전체조회 메소드 실행시간 측정, 사용하지 않는 컬럼조회를 제거하여 쿼리성능 개선, 엔티티별로 QueryDto 를 분리하라

### DIFF
--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupQuestionRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupQuestionRestController.java
@@ -20,6 +20,7 @@ import prgrms.project.stuti.domain.studygroup.service.StudyGroupQuestionService;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupQuestionDto;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupQuestionResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupQuestionsResponse;
+import prgrms.project.stuti.global.aop.ExecutionTimeLogger;
 import prgrms.project.stuti.global.page.PageResponse;
 
 @RestController
@@ -42,6 +43,7 @@ public class StudyGroupQuestionRestController {
 		return ResponseEntity.ok(questionResponse);
 	}
 
+	@ExecutionTimeLogger
 	@GetMapping
 	public ResponseEntity<PageResponse<StudyGroupQuestionsResponse>> getStudyGroupQuestions(
 		@PathVariable Long studyGroupId, @RequestParam(defaultValue = DEFAULT_SIZE) Long size,

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/controller/StudyGroupRestController.java
@@ -21,6 +21,7 @@ import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupDto;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupDetailResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupsResponse;
+import prgrms.project.stuti.global.aop.ExecutionTimeLogger;
 import prgrms.project.stuti.global.page.CursorPageResponse;
 
 @RestController
@@ -41,6 +42,7 @@ public class StudyGroupRestController {
 		return ResponseEntity.ok(idResponse);
 	}
 
+	@ExecutionTimeLogger
 	@GetMapping
 	public ResponseEntity<CursorPageResponse<StudyGroupsResponse>> getStudyGroups(
 		@RequestParam(defaultValue = DEFAULT_SIZE) Long size, StudyGroupRequest.FindCondition condition
@@ -52,6 +54,7 @@ public class StudyGroupRestController {
 		return ResponseEntity.ok(studyGroupsResponse);
 	}
 
+	@ExecutionTimeLogger
 	@GetMapping("/members/{memberId}")
 	public ResponseEntity<CursorPageResponse<StudyGroupsResponse>> getMemberStudyGroups(
 		@PathVariable Long memberId, @RequestParam(defaultValue = DEFAULT_SIZE) Long size,

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/dto/StudyGroupMemberQueryDto.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/dto/StudyGroupMemberQueryDto.java
@@ -1,0 +1,18 @@
+package prgrms.project.stuti.domain.studygroup.repository.dto;
+
+import prgrms.project.stuti.domain.member.model.Career;
+import prgrms.project.stuti.domain.member.model.Field;
+import prgrms.project.stuti.domain.member.model.Mbti;
+import prgrms.project.stuti.domain.studygroup.model.StudyGroupMemberRole;
+
+public record StudyGroupMemberQueryDto(
+	Long studyGroupMemberId,
+	String profileImageUrl,
+	String nickname,
+	Field field,
+	Career career,
+	Mbti mbti,
+	StudyGroupMemberRole studyGroupMemberRole
+) {
+
+}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/dto/StudyGroupQueryDto.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/dto/StudyGroupQueryDto.java
@@ -8,7 +8,6 @@ import prgrms.project.stuti.domain.member.model.Field;
 import prgrms.project.stuti.domain.member.model.Mbti;
 import prgrms.project.stuti.domain.studygroup.model.Region;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
-import prgrms.project.stuti.domain.studygroup.model.StudyGroupMemberRole;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
 
 public record StudyGroupQueryDto() {
@@ -46,18 +45,6 @@ public record StudyGroupQueryDto() {
 	public static record StudyGroupDto(
 		StudyGroup studyGroup,
 		Long memberId
-	) {
-
-	}
-
-	public static record StudyGroupMemberDto(
-		Long studyGroupMemberId,
-		String profileImageUrl,
-		String nickname,
-		Field field,
-		Career career,
-		Mbti mbti,
-		StudyGroupMemberRole studyGroupMemberRole
 	) {
 
 	}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/dto/StudyGroupQueryDto.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/dto/StudyGroupQueryDto.java
@@ -1,6 +1,7 @@
 package prgrms.project.stuti.domain.studygroup.repository.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import prgrms.project.stuti.domain.member.model.Career;
 import prgrms.project.stuti.domain.member.model.Field;
@@ -36,6 +37,13 @@ public record StudyGroupQueryDto() {
 	}
 
 	public static record StudyGroupsDto(
+		List<StudyGroupDto> studyGroupDtos,
+		boolean hasNext
+	) {
+
+	}
+
+	public static record StudyGroupDto(
 		StudyGroup studyGroup,
 		Long memberId
 	) {

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/CustomStudyGroupRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/CustomStudyGroupRepository.java
@@ -15,9 +15,9 @@ public interface CustomStudyGroupRepository {
 
 	List<StudyGroupQueryDto.StudyGroupDetailDto> findStudyGroupDetailById(Long studyGroupId);
 
-	CursorPageResponse<StudyGroupsResponse> findAllWithCursorPaginationByConditions(
+	StudyGroupQueryDto.StudyGroupsDto findAllWithCursorPaginationByConditions(
 		StudyGroupDto.FindCondition conditionDto);
 
-	CursorPageResponse<StudyGroupsResponse> findMembersAllWithCursorPaginationByConditions(
+	StudyGroupQueryDto.StudyGroupsDto findMembersAllWithCursorPaginationByConditions(
 		StudyGroupDto.FindCondition conditionDto);
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyGroupMemberRepository.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyGroupMemberRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroupMember;
-import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupQueryDto;
+import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupMemberQueryDto;
 
 public interface CustomStudyGroupMemberRepository {
 
@@ -14,5 +14,5 @@ public interface CustomStudyGroupMemberRepository {
 
 	Optional<StudyGroupMember> findStudyGroupMemberById(Long studyGroupMemberId);
 
-	Map<StudyGroup, List<StudyGroupQueryDto.StudyGroupMemberDto>> findStudyGroupMembersByStudyGroupId(Long studyGroupId);
+	Map<StudyGroup, List<StudyGroupMemberQueryDto>> findStudyGroupMembersByStudyGroupId(Long studyGroupId);
 }

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyGroupMemberRepositoryImpl.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/repository/studymember/CustomStudyGroupMemberRepositoryImpl.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroupMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroupMemberRole;
-import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupQueryDto;
+import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupMemberQueryDto;
 
 @RequiredArgsConstructor
 public class CustomStudyGroupMemberRepositoryImpl implements CustomStudyGroupMemberRepository {
@@ -53,7 +53,7 @@ public class CustomStudyGroupMemberRepositoryImpl implements CustomStudyGroupMem
 	}
 
 	@Override
-	public Map<StudyGroup, List<StudyGroupQueryDto.StudyGroupMemberDto>> findStudyGroupMembersByStudyGroupId(
+	public Map<StudyGroup, List<StudyGroupMemberQueryDto>> findStudyGroupMembersByStudyGroupId(
 		Long studyGroupId
 	) {
 		return jpaQueryFactory
@@ -64,7 +64,7 @@ public class CustomStudyGroupMemberRepositoryImpl implements CustomStudyGroupMem
 			.orderBy(studyGroupMember.createdAt.asc())
 			.transform(groupBy(studyGroup).as(
 				list(Projections.constructor(
-					StudyGroupQueryDto.StudyGroupMemberDto.class, studyGroupMember.id, member.profileImageUrl,
+					StudyGroupMemberQueryDto.class, studyGroupMember.id, member.profileImageUrl,
 					member.nickName, member.field, member.career, member.mbti,
 					studyGroupMember.studyGroupMemberRole))));
 	}

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupConverter.java
@@ -68,9 +68,9 @@ public class StudyGroupConverter {
 	}
 
 	public static CursorPageResponse<StudyGroupsResponse> toStudyGroupsCursorPageResponse(
-		List<StudyGroupQueryDto.StudyGroupsDto> contents, boolean hasNext
+		StudyGroupQueryDto.StudyGroupsDto studyGroupsDto
 	) {
-		return new CursorPageResponse<>(toStudyGroupsResponse(contents), hasNext);
+		return new CursorPageResponse<>(toStudyGroupsResponse(studyGroupsDto), studyGroupsDto.hasNext());
 	}
 
 	private static Set<PreferredMbti> toPreferredMBTIs(Set<Mbti> preferredMBTIs) {
@@ -95,19 +95,21 @@ public class StudyGroupConverter {
 			.build();
 	}
 
-	private static List<StudyGroupsResponse> toStudyGroupsResponse(List<StudyGroupQueryDto.StudyGroupsDto> contents) {
-		return contents.isEmpty()
+	private static List<StudyGroupsResponse> toStudyGroupsResponse(StudyGroupQueryDto.StudyGroupsDto studyGroupsDto) {
+		List<StudyGroupQueryDto.StudyGroupDto> studyGroupDtos = studyGroupsDto.studyGroupDtos();
+
+		return studyGroupDtos.isEmpty()
 			? Collections.emptyList()
-			: contents
+			: studyGroupDtos
 			.stream()
-			.map(content -> {
-				StudyGroup studyGroup = content.studyGroup();
+			.map(dto -> {
+				StudyGroup studyGroup = dto.studyGroup();
 				StudyPeriod studyPeriod = studyGroup.getStudyPeriod();
 
 				return StudyGroupsResponse
 					.builder()
 					.studyGroupId(studyGroup.getId())
-					.memberId(content.memberId())
+					.memberId(dto.memberId())
 					.imageUrl(studyGroup.getImageUrl())
 					.topic(studyGroup.getTopic().getValue())
 					.title(studyGroup.getTitle())

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupMemberConverter.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupMemberConverter.java
@@ -9,7 +9,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroupMemberRole;
-import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupQueryDto;
+import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupMemberQueryDto;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupMemberIdResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupMembersResponse;
 import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupMembersResponse.StudyGroupMemberResponse;
@@ -22,10 +22,10 @@ public class StudyGroupMemberConverter {
 	}
 
 	public static StudyGroupMembersResponse toStudyGroupMembersResponse(
-		StudyGroup studyGroup, List<StudyGroupQueryDto.StudyGroupMemberDto> studyGroupMemberQueryDtos
+		StudyGroup studyGroup, List<StudyGroupMemberQueryDto> studyGroupMemberQueryDtos
 	) {
 
-		Map<Boolean, List<StudyGroupQueryDto.StudyGroupMemberDto>> studyGroupMembersDtoMap = studyGroupMemberQueryDtos
+		Map<Boolean, List<StudyGroupMemberQueryDto>> studyGroupMembersDtoMap = studyGroupMemberQueryDtos
 			.stream()
 			.collect(Collectors.partitioningBy(
 				dto -> dto.studyGroupMemberRole().equals(StudyGroupMemberRole.STUDY_APPLICANT)));
@@ -44,7 +44,7 @@ public class StudyGroupMemberConverter {
 	}
 
 	private static List<StudyGroupMemberResponse> toStudyGroupMemberResponse(
-		List<StudyGroupQueryDto.StudyGroupMemberDto> studyGroupMemberDtos
+		List<StudyGroupMemberQueryDto> studyGroupMemberDtos
 	) {
 		return studyGroupMemberDtos.isEmpty()
 			? Collections.emptyList()

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupMemberService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupMemberService.java
@@ -14,7 +14,7 @@ import prgrms.project.stuti.domain.member.repository.MemberRepository;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroup;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroupMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroupMemberRole;
-import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupQueryDto;
+import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupMemberQueryDto;
 import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
 import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyGroupMemberRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupMemberDto;
@@ -41,7 +41,7 @@ public class StudyGroupMemberService {
 
 	@Transactional(readOnly = true)
 	public StudyGroupMembersResponse getStudyGroupMembers(StudyGroupMemberDto.ReadDto readDto) {
-		Map<StudyGroup, List<StudyGroupQueryDto.StudyGroupMemberDto>> studyGroupMemberDtoMap =
+		Map<StudyGroup, List<StudyGroupMemberQueryDto>> studyGroupMemberDtoMap =
 			studyGroupMemberRepository.findStudyGroupMembersByStudyGroupId(readDto.studyGroupId());
 		StudyGroup studyGroup = studyGroupMemberDtoMap
 			.keySet()

--- a/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupService.java
+++ b/src/main/java/prgrms/project/stuti/domain/studygroup/service/StudyGroupService.java
@@ -45,12 +45,18 @@ public class StudyGroupService {
 
 	@Transactional(readOnly = true)
 	public CursorPageResponse<StudyGroupsResponse> getStudyGroups(StudyGroupDto.FindCondition conditionDto) {
-		return studyGroupRepository.findAllWithCursorPaginationByConditions(conditionDto);
+		StudyGroupQueryDto.StudyGroupsDto studyGroupsDto =
+			studyGroupRepository.findAllWithCursorPaginationByConditions(conditionDto);
+
+		return StudyGroupConverter.toStudyGroupsCursorPageResponse(studyGroupsDto);
 	}
 
 	@Transactional(readOnly = true)
 	public CursorPageResponse<StudyGroupsResponse> getMemberStudyGroups(StudyGroupDto.FindCondition conditionDto) {
-		return studyGroupRepository.findMembersAllWithCursorPaginationByConditions(conditionDto);
+		StudyGroupQueryDto.StudyGroupsDto studyGroupsDto =
+			studyGroupRepository.findMembersAllWithCursorPaginationByConditions(conditionDto);
+
+		return StudyGroupConverter.toStudyGroupsCursorPageResponse(studyGroupsDto);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/prgrms/project/stuti/global/aop/ExecutionTimeLogger.java
+++ b/src/main/java/prgrms/project/stuti/global/aop/ExecutionTimeLogger.java
@@ -1,0 +1,11 @@
+package prgrms.project.stuti.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExecutionTimeLogger {
+}

--- a/src/main/java/prgrms/project/stuti/global/aop/ExecutionTimer.java
+++ b/src/main/java/prgrms/project/stuti/global/aop/ExecutionTimer.java
@@ -1,0 +1,43 @@
+package prgrms.project.stuti.global.aop;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+public class ExecutionTimer {
+
+	@Pointcut("@annotation(prgrms.project.stuti.global.aop.ExecutionTimeLogger)")
+	private void measureExecutionTime() {
+	}
+
+	@Around("measureExecutionTime()")
+	public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		long start = System.currentTimeMillis();
+		Object response = joinPoint.proceed();
+		Method method = getMethod(joinPoint);
+
+		log.info("실행 메소드: {}, 총 실행시간: {}ms", method.getName(), getTotalMillis(start));
+
+		return response;
+	}
+
+	private Method getMethod(ProceedingJoinPoint joinPoint) {
+		MethodSignature methodSignature = (MethodSignature)joinPoint.getSignature();
+
+		return methodSignature.getMethod();
+	}
+
+	private long getTotalMillis(long start) {
+		return System.currentTimeMillis() - start;
+	}
+}

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/StudyGroupRepositoryTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studygroup/StudyGroupRepositoryTest.java
@@ -24,8 +24,6 @@ import prgrms.project.stuti.domain.studygroup.model.Topic;
 import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupQueryDto;
 import prgrms.project.stuti.domain.studygroup.repository.studymember.StudyGroupMemberRepository;
 import prgrms.project.stuti.domain.studygroup.service.dto.StudyGroupDto;
-import prgrms.project.stuti.domain.studygroup.service.response.StudyGroupsResponse;
-import prgrms.project.stuti.global.page.CursorPageResponse;
 
 class StudyGroupRepositoryTest extends RepositoryTestConfig {
 
@@ -104,14 +102,15 @@ class StudyGroupRepositoryTest extends RepositoryTestConfig {
 			.build();
 
 		//when
-		CursorPageResponse<StudyGroupsResponse> pageResponses =
+		StudyGroupQueryDto.StudyGroupsDto studyGroupsDto =
 			studyGroupRepository.findAllWithCursorPaginationByConditions(conditionDto);
 
 		//then
-		assertThat(pageResponses.contents()).isNotNull();
-		assertThat(pageResponses.contents()).hasSize(3);
-		assertThat(pageResponses.hasNext()).isTrue();
-		pageResponses.contents().forEach(content -> assertThat(content.topic()).isEqualTo(Topic.BACKEND.getValue()));
+		assertThat(studyGroupsDto.studyGroupDtos()).isNotNull();
+		assertThat(studyGroupsDto.studyGroupDtos()).hasSize(3);
+		assertThat(studyGroupsDto.hasNext()).isTrue();
+		studyGroupsDto.studyGroupDtos()
+			.forEach(dto -> assertThat(dto.studyGroup().getTopic()).isEqualTo(Topic.BACKEND));
 	}
 
 	@Test
@@ -130,14 +129,14 @@ class StudyGroupRepositoryTest extends RepositoryTestConfig {
 			.build();
 
 		//when
-		CursorPageResponse<StudyGroupsResponse> pageResponses =
+		StudyGroupQueryDto.StudyGroupsDto studyGroupsDto =
 			studyGroupRepository.findAllWithCursorPaginationByConditions(conditionDto);
 
 		//then
-		assertThat(pageResponses.contents()).isNotNull();
-		assertThat(pageResponses.contents()).hasSize(3);
-		assertThat(pageResponses.hasNext()).isTrue();
-		pageResponses.contents().forEach(content -> assertThat(content.memberId()).isEqualTo(member.getId()));
+		assertThat(studyGroupsDto.studyGroupDtos()).isNotNull();
+		assertThat(studyGroupsDto.studyGroupDtos()).hasSize(3);
+		assertThat(studyGroupsDto.hasNext()).isTrue();
+		studyGroupsDto.studyGroupDtos().forEach(content -> assertThat(content.memberId()).isEqualTo(member.getId()));
 	}
 
 	public void saveStudyGroup(Topic topic) {

--- a/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyGroupMemberRepositoryTest.java
+++ b/src/test/java/prgrms/project/stuti/domain/studygroup/repository/studymember/StudyGroupMemberRepositoryTest.java
@@ -27,7 +27,7 @@ import prgrms.project.stuti.domain.studygroup.model.StudyGroupMember;
 import prgrms.project.stuti.domain.studygroup.model.StudyGroupMemberRole;
 import prgrms.project.stuti.domain.studygroup.model.StudyPeriod;
 import prgrms.project.stuti.domain.studygroup.model.Topic;
-import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupQueryDto;
+import prgrms.project.stuti.domain.studygroup.repository.dto.StudyGroupMemberQueryDto;
 import prgrms.project.stuti.domain.studygroup.repository.studygroup.StudyGroupRepository;
 
 class StudyGroupMemberRepositoryTest extends RepositoryTestConfig {
@@ -152,7 +152,7 @@ class StudyGroupMemberRepositoryTest extends RepositoryTestConfig {
 		Long studyGroupId = studyGroup.getId();
 
 		//when
-		Map<StudyGroup, List<StudyGroupQueryDto.StudyGroupMemberDto>> studyGroupMembersMap =
+		Map<StudyGroup, List<StudyGroupMemberQueryDto>> studyGroupMembersMap =
 			studyGroupMemberRepository.findStudyGroupMembersByStudyGroupId(studyGroupId);
 
 		//then


### PR DESCRIPTION
## ✅ PR 포인트
- 스터디 그룹 전체조회 메소드 실행시간 측정, 사용하지 않는 컬럼조회를 제거하여 쿼리성능 개선, 엔티티별로 QueryDto 를 분리하라

## 🙉 고민했던 부분

## 🙋 질문
